### PR TITLE
Ability to switch what Http Client is used. 

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,17 +8,23 @@
 
 package datadog
 
+import "net/http"
+
 // Client is the object that handles talking to the Datadog API. This maintains
 // state information for a particular application connection.
 type Client struct {
 	apiKey, appKey string
+
+	//The Http Client that is used to make requests
+	HttpClient *http.Client
 }
 
 // NewClient returns a new datadog.Client which can be used to access the API
 // methods. The expected argument is the API key.
 func NewClient(apiKey, appKey string) *Client {
 	return &Client{
-		apiKey: apiKey,
-		appKey: appKey,
+		apiKey:     apiKey,
+		appKey:     appKey,
+		HttpClient: http.DefaultClient,
 	}
 }

--- a/request.go
+++ b/request.go
@@ -53,7 +53,7 @@ func (self *Client) doJsonRequest(method, api string,
 	}
 
 	// Actually do the request, error back if something crazy happened.
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := self.HttpClient.Do(req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This let's you change what the http client is used, but defaults to the `http.DefaultClient`.

This is particularly useful on Google App Engine, where http.DefaultClient isn't available, and you can't use it. You _have_ to use their [urlfetch](https://developers.google.com/appengine/docs/go/urlfetch/) service.

This was directly inspired by how [SendGrid's integration](https://github.com/sendgrid/sendgrid-go#appengine-example) does it.
