### PR TITLE
Ensure body is closed after reading

### DIFF
--- a/request.go
+++ b/request.go
@@ -57,6 +57,8 @@ func (self *Client) doJsonRequest(method, api string,
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return errors.New("API error: " + resp.Status)
 	}


### PR DESCRIPTION
Not closing a HTTP response's body leads to a memory leak