### PR TITLE
Metric.Type in JSON must be key `metric_type`

### DIFF
--- a/series.go
+++ b/series.go
@@ -17,7 +17,7 @@ type DataPoint [2]float64
 type Metric struct {
 	Metric string      `json:"metric"`
 	Points []DataPoint `json:"points"`
-	Type   string      `json:"type"`
+	Type   string      `json:"metric_type"`
 	Host   string      `json:"host"`
 	Tags   []string    `json:"tags"`
 }


### PR DESCRIPTION
According to the API documentation as of today, this is the proper key.

http://docs.datadoghq.com/api/#metrics-post

/cc @zorkian 