### PR TITLE
Fix API endpoint for inviting new users

### DIFF
--- a/users.go
+++ b/users.go
@@ -15,6 +15,6 @@ type reqInviteUsers struct {
 
 // InviteUsers takes a slice of email addresses and sends invitations to them.
 func (self *Client) InviteUsers(emails []string) error {
-	return self.doJsonRequest("POST", "/v1/account/invite",
+	return self.doJsonRequest("POST", "/v1/invite_users",
 		reqInviteUsers{Emails: emails}, nil)
 }


### PR DESCRIPTION
`api/v1/account/invite` results in HTTP status code 404. 

According to [the docs](http://docs.datadoghq.com/api/#users), the correct endpoint is `api/v1/invite_users`.