### PR TITLE
Screenboards Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
   - 1.4
+  - tip
 env:
   - "PATH=/home/travis/gopath/bin:$PATH"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ script:
   - go get -u github.com/golang/lint/golint
   - golint ./...
   - test `gofmt -l . | wc -l` = 0
+  - make test
 
 install:
   - go get -t -d -v ./..

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: go
+go:
+  - 1.4
+env:
+  - "PATH=/home/travis/gopath/bin:$PATH"
+script:
+  - go get -u github.com/golang/lint/golint
+  - golint ./...
+  - test `gofmt -l . | wc -l` = 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ script:
   - go get -u github.com/golang/lint/golint
   - golint ./...
   - test `gofmt -l . | wc -l` = 0
+
+install:
+  - go get -t -d -v ./..

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 go:
   - 1.4
-  - tip
 env:
   - "PATH=/home/travis/gopath/bin:$PATH"
 script:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,50 @@
+TEST?=.
+VETARGS?=-asmdecl -atomic -bool -buildtags -copylocks -methods -nilfunc -printf -rangeloops -shift -structtags -unsafeptr
+
+default: test
+
+# get dependencies
+updatedeps:
+	go list ./... \
+        | xargs go list -f '{{join .Deps "\n"}}' \
+		| grep -v go-datadog-api\
+        | grep -v '/internal/' \
+        | sort -u \
+        | xargs go get -f -u -v
+
+# test runs the unit tests and vets the code
+test:
+	TF_ACC= go test . $(TESTARGS) -timeout=30s -parallel=4
+	@$(MAKE) vet
+
+# testacc runs acceptance tests
+testacc:
+	TF_ACC=1 go test integration_test/* -v $(TESTARGS) -timeout 90m
+
+# testrace runs the race checker
+testrace: generate
+	TF_ACC= go test -race $(TEST) $(TESTARGS)
+
+cover:
+	@go tool cover 2>/dev/null; if [ $$? -eq 3 ]; then \
+		go get -u golang.org/x/tools/cmd/cover; \
+	fi
+	go test $(TEST) -coverprofile=coverage.out
+	go tool cover -html=coverage.out
+	rm coverage.out
+
+# vet runs the Go source code static analysis tool `vet` to find
+# any common errors.
+vet:
+	@go tool vet 2>/dev/null ; if [ $$? -eq 3 ]; then \
+		go get golang.org/x/tools/cmd/vet; \
+	fi
+	@echo "go tool vet $(VETARGS) $(TEST) "
+	@go tool vet $(VETARGS) $(TEST) ; if [ $$? -eq 1 ]; then \
+		echo ""; \
+		echo "Vet found suspicious constructs. Please check the reported constructs"; \
+		echo "and fix them if necessary before submitting the code for review."; \
+		exit 1; \
+	fi
+
+.PHONY: default test updatedeps vet

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ testacc:
 	TF_ACC=1 go test integration_test/* -v $(TESTARGS) -timeout 90m
 
 # testrace runs the race checker
-testrace: generate
+testrace:
 	TF_ACC= go test -race $(TEST) $(TESTARGS)
 
 cover:

--- a/Makefile
+++ b/Makefile
@@ -25,14 +25,6 @@ testacc:
 testrace:
 	TF_ACC= go test -race $(TEST) $(TESTARGS)
 
-cover:
-	@go tool cover 2>/dev/null; if [ $$? -eq 3 ]; then \
-		go get -u golang.org/x/tools/cmd/cover; \
-	fi
-	go test $(TEST) -coverprofile=coverage.out
-	go tool cover -html=coverage.out
-	rm coverage.out
-
 # vet runs the Go source code static analysis tool `vet` to find
 # any common errors.
 vet:
@@ -47,4 +39,4 @@ vet:
 		exit 1; \
 	fi
 
-.PHONY: default test updatedeps vet
+.PHONY: default test testacc updatedeps vet

--- a/README.md
+++ b/README.md
@@ -15,10 +15,13 @@ The source API documentation is here: <http://docs.datadoghq.com/api/>
 
 To use this project, include it in your code like:
 
+``` sh
     import "github.com/zorkian/go-datadog-api"
+```
 
 Then, you can work with it:
 
+``` sh
     client := datadog.NewClient("api key", "application key")
     
     dash, err := client.GetDashboard(10880)
@@ -26,6 +29,7 @@ Then, you can work with it:
         log.Fatalf("fatal: %s\n", err)
     }
     log.Printf("dashboard %d: %s\n", dash.Id, dash.Title)
+```
 
 That's all; it's pretty easy to use.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build
-status](https://travis-ci.org/ojongerius/go-datadog-api.svg)](https://travis-ci.org/ojongerius/go-datadog-api)
+status](https://travis-ci.org/zorkian/go-datadog-api.svg)](https://travis-ci.org/zorkian/go-datadog-api)
 
 # Datadog API in Go
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ The source API documentation is here: <http://docs.datadoghq.com/api/>
 
 To use this project, include it in your code like:
 
-``` sh
+``` go
     import "github.com/zorkian/go-datadog-api"
 ```
 
 Then, you can work with it:
 
-``` sh
+``` go
     client := datadog.NewClient("api key", "application key")
     
     dash, err := client.GetDashboard(10880)

--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ Github:
 
 Thanks in advance! And, as always, patches welcome!
 
+## DEVELOPMENT
+
+* Get dependencies with `make updatedeps`.
+* Run tests tests with `make test`.
+* Integration tests can be run with `make testacc`.
+
+The acceptance tests require _DATADOG_API_KEY_ and _DATADOG_APP_KEY_ to be available
+in your environment variables.
+
+*Warning: the integrations tests will create and remove real resources in your Datadog
+account*
+
 ## COPYRIGHT AND LICENSE
 
 Please see the LICENSE file for the included license information.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build
+status](https://travis-ci.org/ojongerius/go-datadog-api.svg)](https://travis-ci.org/ojongerius/go-datadog-api)
+
 # Datadog API in Go
 
 Hi!

--- a/integration_test/screen_widgets_test.go
+++ b/integration_test/screen_widgets_test.go
@@ -3,7 +3,7 @@ package integration_test
 import (
 	"testing"
 
-	"github.com/seiffert/go-datadog-api"
+	"github.com/ojongerius/go-datadog-api"
 )
 
 func TestFreeTextWidget(t *testing.T) {

--- a/integration_test/screen_widgets_test.go
+++ b/integration_test/screen_widgets_test.go
@@ -6,6 +6,307 @@ import (
 	"github.com/ojongerius/go-datadog-api"
 )
 
+func TestAlertValueWidget(t *testing.T) {
+	board := createTestScreenboard(t)
+
+	expected := datadog.Widget{}.AlertValueWidget
+
+	expected.X = 1
+	expected.Y = 1
+	expected.Width = 5
+	expected.Height = 5
+	expected.TitleText = "foo"
+	expected.TitleAlign = "center"
+	expected.TitleSize = 1
+	expected.Title = true
+	expected.TextSize = "auto"
+	expected.Precision = 2
+	expected.AlertId = 1
+	expected.Type = "alert_value"
+	expected.Unit = "auto"
+	expected.AddTimeframe = false
+
+	w := datadog.Widget{AlertValueWidget: expected}
+
+	board.Widgets = append(board.Widgets, w)
+
+	if err := client.UpdateScreenboard(board); err != nil {
+		t.Fatalf("Updating a screenboard failed: %s", err)
+	}
+
+	actual, err := client.GetScreenboard(board.Id)
+	if err != nil {
+		t.Fatalf("Retreiving a screenboard failed: %s", err)
+	}
+
+	actualWidget := actual.Widgets[0].AlertValueWidget
+
+	assertEquals(t, "x", actualWidget.X, expected.X)
+	assertEquals(t, "y", actualWidget.Y, expected.Y)
+	assertEquals(t, "height", actualWidget.Height, expected.Height)
+	assertEquals(t, "width", actualWidget.Width, expected.Width)
+	assertEquals(t, "title_text", actualWidget.TitleText, expected.TitleText)
+	assertEquals(t, "title_size", actualWidget.TitleSize, expected.TitleSize)
+	assertEquals(t, "title_align", actualWidget.TitleAlign, expected.TitleAlign)
+	assertEquals(t, "title", actualWidget.Title, expected.Title)
+	assertEquals(t, "text_size", actualWidget.TextSize, expected.TextSize)
+	assertEquals(t, "precision", actualWidget.Precision, expected.Precision)
+	assertEquals(t, "alert_id", actualWidget.AlertId, expected.AlertId)
+	assertEquals(t, "type", actualWidget.Type, expected.Type)
+	assertEquals(t, "unit", actualWidget.Unit, expected.Unit)
+	assertEquals(t, "add_timeframe", actualWidget.AddTimeframe, expected.AddTimeframe)
+
+	cleanUpScreenboard(t, board.Id)
+}
+
+func TestChangeWidget(t *testing.T) {
+	board := createTestScreenboard(t)
+
+	expected := datadog.Widget{}.ChangeWidget
+
+	expected.X = 1
+	expected.Y = 1
+	expected.Width = 5
+	expected.Height = 5
+	expected.TitleText = "foo"
+	expected.TitleAlign = "center"
+	expected.TitleSize = 1
+	expected.Title = true
+	expected.Aggregator = "min"
+	expected.TileDef = datadog.TileDef{}
+
+	w := datadog.Widget{ChangeWidget: expected}
+
+	board.Widgets = append(board.Widgets, w)
+
+	if err := client.UpdateScreenboard(board); err != nil {
+		t.Fatalf("Updating a screenboard failed: %s", err)
+	}
+
+	actual, err := client.GetScreenboard(board.Id)
+	if err != nil {
+		t.Fatalf("Retreiving a screenboard failed: %s", err)
+	}
+
+	actualWidget := actual.Widgets[0].ChangeWidget
+
+	assertEquals(t, "x", actualWidget.X, expected.X)
+	assertEquals(t, "y", actualWidget.Y, expected.Y)
+	assertEquals(t, "height", actualWidget.Height, expected.Height)
+	assertEquals(t, "width", actualWidget.Width, expected.Width)
+	assertEquals(t, "title_text", actualWidget.TitleText, expected.TitleText)
+	assertEquals(t, "title_size", actualWidget.TitleSize, expected.TitleSize)
+	assertEquals(t, "title_align", actualWidget.TitleAlign, expected.TitleAlign)
+	assertEquals(t, "title", actualWidget.Title, expected.Title)
+	assertEquals(t, "aggregator", actualWidget.Aggregator, expected.Aggregator)
+	assertTileDefEquals(t, actualWidget.TileDef, expected.TileDef)
+
+	cleanUpScreenboard(t, board.Id)
+}
+
+func TestGraphWidget(t *testing.T) {
+	board := createTestScreenboard(t)
+
+	expected := datadog.Widget{}.GraphWidget
+
+	expected.X = 1
+	expected.Y = 1
+	expected.Width = 5
+	expected.Height = 5
+	expected.TitleText = "foo"
+	expected.TitleAlign = "center"
+	expected.TitleSize = 1
+	expected.Title = true
+	expected.Timeframe = "1d"
+	expected.Type = "alert_graph"
+	expected.Legend = true
+	expected.LegendSize = 5
+	expected.TileDef = datadog.TileDef{}
+
+	w := datadog.Widget{GraphWidget: expected}
+
+	board.Widgets = append(board.Widgets, w)
+
+	if err := client.UpdateScreenboard(board); err != nil {
+		t.Fatalf("Updating a screenboard failed: %s", err)
+	}
+
+	actual, err := client.GetScreenboard(board.Id)
+	if err != nil {
+		t.Fatalf("Retreiving a screenboard failed: %s", err)
+	}
+
+	actualWidget := actual.Widgets[0].GraphWidget
+
+	assertEquals(t, "x", actualWidget.X, expected.X)
+	assertEquals(t, "y", actualWidget.Y, expected.Y)
+	assertEquals(t, "height", actualWidget.Height, expected.Height)
+	assertEquals(t, "width", actualWidget.Width, expected.Width)
+	assertEquals(t, "title_text", actualWidget.TitleText, expected.TitleText)
+	assertEquals(t, "title_size", actualWidget.TitleSize, expected.TitleSize)
+	assertEquals(t, "title_align", actualWidget.TitleAlign, expected.TitleAlign)
+	assertEquals(t, "title", actualWidget.Title, expected.Title)
+	assertEquals(t, "type", actualWidget.Type, expected.Type)
+	assertEquals(t, "timeframe", actualWidget.Timeframe, expected.Timeframe)
+	assertEquals(t, "legend", actualWidget.Legend, expected.Legend)
+	assertEquals(t, "legend_size", actualWidget.LegendSize, expected.LegendSize)
+	assertTileDefEquals(t, actualWidget.TileDef, expected.TileDef)
+
+	cleanUpScreenboard(t, board.Id)
+}
+
+func TestEventTimelineWidget(t *testing.T) {
+	board := createTestScreenboard(t)
+
+	expected := datadog.Widget{}.EventTimelineWidget
+
+	expected.X = 1
+	expected.Y = 1
+	expected.Width = 5
+	expected.Height = 5
+	expected.TitleText = "foo"
+	expected.TitleAlign = "center"
+	expected.TitleSize = 1
+	expected.Title = true
+	expected.Query = "avg:system.load.1{foo} by {bar}"
+	expected.Timeframe = "1d"
+	expected.Type = "alert_graph"
+
+	w := datadog.Widget{EventTimelineWidget: expected}
+
+	board.Widgets = append(board.Widgets, w)
+
+	if err := client.UpdateScreenboard(board); err != nil {
+		t.Fatalf("Updating a screenboard failed: %s", err)
+	}
+
+	actual, err := client.GetScreenboard(board.Id)
+	if err != nil {
+		t.Fatalf("Retreiving a screenboard failed: %s", err)
+	}
+
+	actualWidget := actual.Widgets[0].EventTimelineWidget
+
+	assertEquals(t, "x", actualWidget.X, expected.X)
+	assertEquals(t, "y", actualWidget.Y, expected.Y)
+	assertEquals(t, "height", actualWidget.Height, expected.Height)
+	assertEquals(t, "width", actualWidget.Width, expected.Width)
+	assertEquals(t, "title_text", actualWidget.TitleText, expected.TitleText)
+	assertEquals(t, "title_size", actualWidget.TitleSize, expected.TitleSize)
+	assertEquals(t, "title_align", actualWidget.TitleAlign, expected.TitleAlign)
+	assertEquals(t, "title", actualWidget.Title, expected.Title)
+	assertEquals(t, "type", actualWidget.Type, expected.Type)
+	assertEquals(t, "query", actualWidget.Query, expected.Query)
+	assertEquals(t, "timeframe", actualWidget.Timeframe, expected.Timeframe)
+
+	cleanUpScreenboard(t, board.Id)
+}
+
+func TestAlertGraphWidget(t *testing.T) {
+	board := createTestScreenboard(t)
+
+	expected := datadog.Widget{}.AlertGraphWidget
+
+	expected.X = 1
+	expected.Y = 1
+	expected.Width = 5
+	expected.Height = 5
+	expected.TitleText = "foo"
+	expected.TitleAlign = "center"
+	expected.TitleSize = 1
+	expected.Title = true
+	expected.VizType = ""
+	expected.Timeframe = "1d"
+	expected.AddTimeframe = false
+	expected.AlertId = 1
+	expected.Type = "alert_graph"
+
+	w := datadog.Widget{AlertGraphWidget: expected}
+
+	board.Widgets = append(board.Widgets, w)
+
+	if err := client.UpdateScreenboard(board); err != nil {
+		t.Fatalf("Updating a screenboard failed: %s", err)
+	}
+
+	actual, err := client.GetScreenboard(board.Id)
+	if err != nil {
+		t.Fatalf("Retreiving a screenboard failed: %s", err)
+	}
+
+	actualWidget := actual.Widgets[0].AlertGraphWidget
+
+	assertEquals(t, "x", actualWidget.X, expected.X)
+	assertEquals(t, "y", actualWidget.Y, expected.Y)
+	assertEquals(t, "height", actualWidget.Height, expected.Height)
+	assertEquals(t, "width", actualWidget.Width, expected.Width)
+	assertEquals(t, "title_text", actualWidget.TitleText, expected.TitleText)
+	assertEquals(t, "title_size", actualWidget.TitleSize, expected.TitleSize)
+	assertEquals(t, "title_align", actualWidget.TitleAlign, expected.TitleAlign)
+	assertEquals(t, "title", actualWidget.Title, expected.Title)
+	assertEquals(t, "type", actualWidget.Type, expected.Type)
+	assertEquals(t, "viz_type", actualWidget.VizType, expected.VizType)
+	assertEquals(t, "timeframe", actualWidget.Timeframe, expected.Timeframe)
+	assertEquals(t, "add_timeframe", actualWidget.AddTimeframe, expected.AddTimeframe)
+	assertEquals(t, "alert_id", actualWidget.AlertId, expected.AlertId)
+
+	cleanUpScreenboard(t, board.Id)
+}
+
+func TestHostMapWidget(t *testing.T) {
+	board := createTestScreenboard(t)
+
+	expected := datadog.Widget{}.HostMapWidget
+
+	expected.X = 1
+	expected.Y = 1
+	expected.Width = 5
+	expected.Height = 5
+	expected.TitleText = "foo"
+	expected.TitleAlign = "center"
+	expected.TitleSize = 1
+	expected.Title = true
+	expected.Type = "check_status"
+	expected.Query = "avg:system.load.1{foo} by {bar}"
+	expected.Timeframe = "1d"
+	expected.Legend = true
+	expected.LegendSize = 5
+	expected.TileDef = datadog.TileDef{}
+
+	w := datadog.Widget{HostMapWidget: expected}
+
+	board.Widgets = append(board.Widgets, w)
+
+	if err := client.UpdateScreenboard(board); err != nil {
+		t.Fatalf("Updating a screenboard failed: %s", err)
+	}
+
+	actual, err := client.GetScreenboard(board.Id)
+	if err != nil {
+		t.Fatalf("Retreiving a screenboard failed: %s", err)
+	}
+
+	actualWidget := actual.Widgets[0].HostMapWidget
+
+	assertEquals(t, "x", actualWidget.X, expected.X)
+	assertEquals(t, "y", actualWidget.Y, expected.Y)
+	assertEquals(t, "height", actualWidget.Height, expected.Height)
+	assertEquals(t, "width", actualWidget.Width, expected.Width)
+	assertEquals(t, "title_text", actualWidget.TitleText, expected.TitleText)
+	assertEquals(t, "title_size", actualWidget.TitleSize, expected.TitleSize)
+	assertEquals(t, "title_align", actualWidget.TitleAlign, expected.TitleAlign)
+	assertEquals(t, "title", actualWidget.Title, expected.Title)
+	assertEquals(t, "type", actualWidget.Type, expected.Type)
+	assertEquals(t, "query", actualWidget.Query, expected.Query)
+	assertEquals(t, "timeframe", actualWidget.Timeframe, expected.Timeframe)
+	assertEquals(t, "query", actualWidget.Query, expected.Query)
+	assertEquals(t, "legend", actualWidget.Legend, expected.Legend)
+	assertEquals(t, "legend_size", actualWidget.LegendSize, expected.LegendSize)
+	assertTileDefEquals(t, actualWidget.TileDef, expected.TileDef)
+
+	cleanUpScreenboard(t, board.Id)
+}
+
 func TestCheckStatusWidget(t *testing.T) {
 	board := createTestScreenboard(t)
 
@@ -180,7 +481,7 @@ func TestToplistWidget(t *testing.T) {
 	expected.Title = false
 	expected.Timeframe = "5m"
 	expected.Legend = false
-	expected.LegendSize = "5"
+	expected.LegendSize = 5
 
 	w := datadog.Widget{ToplistWidget: expected}
 
@@ -408,6 +709,20 @@ func TestQueryValueWidget(t *testing.T) {
 	expected.TimeframeAggregator = "sum"
 	expected.Aggregator = "min"
 	expected.Query = "docker.containers.running"
+	expected.MetricType = "standard"
+	/* TODO: add test for conditional formats
+	"conditional_formats": [{
+		"comparator": ">",
+		"color": "white_on_red",
+		"custom_bg_color": null,
+		"value": 1,
+		"invert": false,
+		"custom_fg_color": null}],
+	*/
+	expected.IsValidQuery = true
+	expected.ResultCalcFunc = "raw"
+	expected.Aggregator = "avg"
+	expected.CalcFunc = "raw"
 
 	w := datadog.Widget{QueryValueWidget: expected}
 
@@ -437,6 +752,9 @@ func TestQueryValueWidget(t *testing.T) {
 	assertEquals(t, "timeframe-aggregator", actualWidget.TimeframeAggregator, expected.TimeframeAggregator)
 	assertEquals(t, "aggregator", actualWidget.Aggregator, expected.Aggregator)
 	assertEquals(t, "query", actualWidget.Query, expected.Query)
+	assertEquals(t, "is_valid_query", actualWidget.IsValidQuery, expected.IsValidQuery)
+	assertEquals(t, "res_calc_func", actualWidget.ResultCalcFunc, expected.ResultCalcFunc)
+	assertEquals(t, "aggr", actualWidget.Aggregator, expected.Aggregator)
 
 	cleanUpScreenboard(t, board.Id)
 }

--- a/integration_test/screen_widgets_test.go
+++ b/integration_test/screen_widgets_test.go
@@ -6,6 +6,164 @@ import (
 	"github.com/ojongerius/go-datadog-api"
 )
 
+func TestCheckStatusWidget(t *testing.T) {
+	board := createTestScreenboard(t)
+
+	expected := datadog.Widget{}.CheckStatusWidget
+
+	expected.X = 1
+	expected.Y = 1
+	expected.Width = 5
+	expected.Height = 5
+	expected.TitleText = "foo"
+	expected.TitleAlign = "center"
+	expected.TitleSize = 1
+	expected.Title = true
+	expected.Type = "check_status"
+	expected.Tags = "foo"
+	expected.Timeframe = "1d"
+	expected.Timeframe = "1d"
+	expected.Check = "datadog.agent.up"
+	expected.Group = "foo"
+	expected.Grouping = "check"
+
+	w := datadog.Widget{CheckStatusWidget: expected}
+
+	board.Widgets = append(board.Widgets, w)
+
+	if err := client.UpdateScreenboard(board); err != nil {
+		t.Fatalf("Updating a screenboard failed: %s", err)
+	}
+
+	actual, err := client.GetScreenboard(board.Id)
+	if err != nil {
+		t.Fatalf("Retreiving a screenboard failed: %s", err)
+	}
+
+	actualWidget := actual.Widgets[0].CheckStatusWidget
+
+	assertEquals(t, "x", actualWidget.X, expected.X)
+	assertEquals(t, "y", actualWidget.Y, expected.Y)
+	assertEquals(t, "height", actualWidget.Height, expected.Height)
+	assertEquals(t, "width", actualWidget.Width, expected.Width)
+	assertEquals(t, "title_text", actualWidget.TitleText, expected.TitleText)
+	assertEquals(t, "title_size", actualWidget.TitleSize, expected.TitleSize)
+	assertEquals(t, "title_align", actualWidget.TitleAlign, expected.TitleAlign)
+	assertEquals(t, "title", actualWidget.Title, expected.Title)
+	assertEquals(t, "type", actualWidget.Type, expected.Type)
+	assertEquals(t, "tags", actualWidget.Tags, expected.Tags)
+	assertEquals(t, "timeframe", actualWidget.Timeframe, expected.Timeframe)
+	assertEquals(t, "check", actualWidget.Check, expected.Check)
+	assertEquals(t, "group", actualWidget.Group, expected.Group)
+	assertEquals(t, "grouping", actualWidget.Grouping, expected.Grouping)
+
+	cleanUpScreenboard(t, board.Id)
+}
+
+func TestIFrameWidget(t *testing.T) {
+	board := createTestScreenboard(t)
+
+	expected := datadog.Widget{}.IFrameWidget
+
+	expected.X = 1
+	expected.Y = 1
+	expected.Width = 5
+	expected.Height = 5
+	expected.TitleText = "foo"
+	expected.TitleAlign = "center"
+	expected.TitleSize = 1
+	expected.Title = true
+	expected.Url = "http://www.example.com"
+	expected.Type = "iframe"
+
+	w := datadog.Widget{IFrameWidget: expected}
+
+	board.Widgets = append(board.Widgets, w)
+
+	if err := client.UpdateScreenboard(board); err != nil {
+		t.Fatalf("Updating a screenboard failed: %s", err)
+	}
+
+	actual, err := client.GetScreenboard(board.Id)
+	if err != nil {
+		t.Fatalf("Retreiving a screenboard failed: %s", err)
+	}
+
+	actualWidget := actual.Widgets[0].IFrameWidget
+
+	assertEquals(t, "x", actualWidget.X, expected.X)
+	assertEquals(t, "y", actualWidget.Y, expected.Y)
+	assertEquals(t, "height", actualWidget.Height, expected.Height)
+	assertEquals(t, "width", actualWidget.Width, expected.Width)
+	assertEquals(t, "title_text", actualWidget.TitleText, expected.TitleText)
+	assertEquals(t, "title_size", actualWidget.TitleSize, expected.TitleSize)
+	assertEquals(t, "title_align", actualWidget.TitleAlign, expected.TitleAlign)
+	assertEquals(t, "title", actualWidget.Title, expected.Title)
+	assertEquals(t, "url", actualWidget.Url, expected.Url)
+	assertEquals(t, "type", actualWidget.Type, expected.Type)
+
+	cleanUpScreenboard(t, board.Id)
+}
+
+func TestNoteWidget(t *testing.T) {
+	board := createTestScreenboard(t)
+
+	expected := datadog.Widget{}.NoteWidget
+
+	expected.X = 1
+	expected.Y = 1
+	expected.Width = 5
+	expected.Height = 5
+	expected.TitleText = "foo"
+	expected.TitleAlign = "center"
+	expected.TitleSize = 1
+	expected.Title = true
+	expected.Color = "green"
+	expected.FontSize = 5
+	expected.RefreshEvery = 60
+	expected.TickPos = "foo"
+	expected.TickEdge = "bar"
+	expected.Html = "<strong>baz</strong>"
+	expected.Tick = false
+	expected.Note = "quz"
+	expected.AutoRefresh = false
+
+	w := datadog.Widget{NoteWidget: expected}
+
+	board.Widgets = append(board.Widgets, w)
+
+	if err := client.UpdateScreenboard(board); err != nil {
+		t.Fatalf("Updating a screenboard failed: %s", err)
+	}
+
+	actual, err := client.GetScreenboard(board.Id)
+	if err != nil {
+		t.Fatalf("Retreiving a screenboard failed: %s", err)
+	}
+
+	actualWidget := actual.Widgets[0].NoteWidget
+
+	assertEquals(t, "x", actualWidget.X, expected.X)
+	assertEquals(t, "y", actualWidget.Y, expected.Y)
+	assertEquals(t, "height", actualWidget.Height, expected.Height)
+	assertEquals(t, "width", actualWidget.Width, expected.Width)
+	assertEquals(t, "title_text", actualWidget.TitleText, expected.TitleText)
+	assertEquals(t, "title_size", actualWidget.TitleSize, expected.TitleSize)
+	assertEquals(t, "title_align", actualWidget.TitleAlign, expected.TitleAlign)
+	assertEquals(t, "title", actualWidget.Title, expected.Title)
+	assertEquals(t, "color", actualWidget.Color, expected.Color)
+	assertEquals(t, "front_size", actualWidget.FontSize, expected.FontSize)
+	assertEquals(t, "refresh_every", actualWidget.RefreshEvery, expected.RefreshEvery)
+	assertEquals(t, "tick_pos", actualWidget.TickPos, expected.TickPos)
+	assertEquals(t, "tick_edge", actualWidget.TickEdge, expected.TickEdge)
+	assertEquals(t, "tick", actualWidget.Tick, expected.Tick)
+	assertEquals(t, "html", actualWidget.Html, expected.Html)
+	assertEquals(t, "note", actualWidget.Note, expected.Note)
+	assertEquals(t, "auto_refresh", actualWidget.AutoRefresh, expected.AutoRefresh)
+
+	cleanUpScreenboard(t, board.Id)
+}
+
 func TestToplistWidget(t *testing.T) {
 	board := createTestScreenboard(t)
 

--- a/integration_test/screen_widgets_test.go
+++ b/integration_test/screen_widgets_test.go
@@ -7,10 +7,10 @@ import (
 )
 
 /* TODO: Add tests for:
-	* ToplistWidget
-	* EventStreamWidget
-	* ImageWidget
-*/
+* ToplistWidget
+* EventStreamWidget
+* ImageWidget
+ */
 
 func TestFreeTextWidget(t *testing.T) {
 	board := createTestScreenboard(t)
@@ -25,7 +25,7 @@ func TestFreeTextWidget(t *testing.T) {
 	expected.FontSize = "16"
 	expected.TextAlign = "center"
 
-	w := datadog.Widget{ FreeTextWidget: expected}
+	w := datadog.Widget{FreeTextWidget: expected}
 
 	board.Widgets = append(board.Widgets, w)
 
@@ -66,7 +66,7 @@ func TestTimeseriesWidget(t *testing.T) {
 	expected.TitleText = "Test"
 	expected.Timeframe = "1m"
 
-	w := datadog.Widget{ TimeseriesWidget: expected}
+	w := datadog.Widget{TimeseriesWidget: expected}
 
 	board.Widgets = append(board.Widgets, w)
 	if err := client.UpdateScreenboard(board); err != nil {
@@ -114,7 +114,7 @@ func TestQueryValueWidget(t *testing.T) {
 	expected.Aggregator = "min"
 	expected.Query = "docker.containers.running"
 
-	w := datadog.Widget{ QueryValueWidget: expected}
+	w := datadog.Widget{QueryValueWidget: expected}
 
 	board.Widgets = append(board.Widgets, w)
 	if err := client.UpdateScreenboard(board); err != nil {

--- a/integration_test/screen_widgets_test.go
+++ b/integration_test/screen_widgets_test.go
@@ -6,14 +6,29 @@ import (
 	"github.com/ojongerius/go-datadog-api"
 )
 
+/* TODO: Add tests for:
+	* ToplistWidget
+	* EventStreamWidget
+	* ImageWidget
+*/
+
 func TestFreeTextWidget(t *testing.T) {
 	board := createTestScreenboard(t)
-	widget := datadog.NewFreeTextWidget(
-		1, 1, 10, 10, "Test", 16, "center",
-	)
-	expected := *(widget.(*datadog.FreeTextWidget))
 
-	board.Widgets = append(board.Widgets, widget)
+	expected := datadog.Widget{}.FreeTextWidget
+
+	expected.X = 1
+	expected.Y = 1
+	expected.Height = 10
+	expected.Width = 10
+	expected.Text = "Test"
+	expected.FontSize = "16"
+	expected.TextAlign = "center"
+
+	w := datadog.Widget{ FreeTextWidget: expected}
+
+	board.Widgets = append(board.Widgets, w)
+
 	if err := client.UpdateScreenboard(board); err != nil {
 		t.Fatalf("Updating a screenboard failed: %s", err)
 	}
@@ -23,10 +38,7 @@ func TestFreeTextWidget(t *testing.T) {
 		t.Fatalf("Retreiving a screenboard failed: %s", err)
 	}
 
-	actualWidget, ok := actual.Widgets[0].(*datadog.FreeTextWidget)
-	if !ok {
-		t.Fatalf("Widget type does not match: %v", actual.Widgets[0])
-	}
+	actualWidget := actual.Widgets[0].FreeTextWidget
 
 	assertEquals(t, "font-size", actualWidget.FontSize, expected.FontSize)
 	assertEquals(t, "height", actualWidget.Height, expected.Height)
@@ -42,17 +54,21 @@ func TestFreeTextWidget(t *testing.T) {
 
 func TestTimeseriesWidget(t *testing.T) {
 	board := createTestScreenboard(t)
-	widget := datadog.NewTimeseriesWidget(
-		1, 1, 20, 30,
-		true, "center", datadog.TextSize{Size: 16}, "Test",
-		"1m",
-		[]datadog.TimeseriesRequest{
-			datadog.NewTimeseriesRequest("line", "system.cpu.idle"),
-		},
-	)
-	expected := *(widget.(*datadog.TimeseriesWidget))
 
-	board.Widgets = append(board.Widgets, widget)
+	expected := datadog.Widget{}.TimeseriesWidget
+	expected.X = 1
+	expected.Y = 1
+	expected.Width = 20
+	expected.Height = 30
+	expected.Title = true
+	expected.TitleAlign = "centre"
+	expected.TitleSize = datadog.TextSize{Size: 16}
+	expected.TitleText = "Test"
+	expected.Timeframe = "1m"
+
+	w := datadog.Widget{ TimeseriesWidget: expected}
+
+	board.Widgets = append(board.Widgets, w)
 	if err := client.UpdateScreenboard(board); err != nil {
 		t.Fatalf("Updating a screenboard failed: %s", err)
 	}
@@ -62,10 +78,7 @@ func TestTimeseriesWidget(t *testing.T) {
 		t.Fatalf("Retreiving a screenboard failed: %s", err)
 	}
 
-	actualWidget, ok := actual.Widgets[0].(*datadog.TimeseriesWidget)
-	if !ok {
-		t.Fatalf("Widget type does not match: %v", actual.Widgets[0])
-	}
+	actualWidget := actual.Widgets[0].TimeseriesWidget
 
 	assertEquals(t, "height", actualWidget.Height, expected.Height)
 	assertEquals(t, "width", actualWidget.Width, expected.Width)
@@ -86,16 +99,24 @@ func TestTimeseriesWidget(t *testing.T) {
 
 func TestQueryValueWidget(t *testing.T) {
 	board := createTestScreenboard(t)
-	widget := datadog.NewQueryValueWidget(
-		1, 1, 20, 10,
-		true, "center", datadog.TextSize{Size: 16}, "Test",
-		"left", datadog.TextSize{Size: 32},
-		"1m", "sum",
-		"min", "docker.containers.running",
-	)
-	expected := *(widget.(*datadog.QueryValueWidget))
 
-	board.Widgets = append(board.Widgets, widget)
+	expected := datadog.Widget{}.QueryValueWidget
+	expected.X = 1
+	expected.Y = 1
+	expected.Width = 20
+	expected.Height = 30
+	expected.Title = true
+	expected.TitleAlign = "centre"
+	expected.TitleSize = datadog.TextSize{Size: 16}
+	expected.TitleText = "Test"
+	expected.Timeframe = "1m"
+	expected.TimeframeAggregator = "sum"
+	expected.Aggregator = "min"
+	expected.Query = "docker.containers.running"
+
+	w := datadog.Widget{ QueryValueWidget: expected}
+
+	board.Widgets = append(board.Widgets, w)
 	if err := client.UpdateScreenboard(board); err != nil {
 		t.Fatalf("Updating a screenboard failed: %s", err)
 	}
@@ -105,10 +126,7 @@ func TestQueryValueWidget(t *testing.T) {
 		t.Fatalf("Retreiving a screenboard failed: %s", err)
 	}
 
-	actualWidget, ok := actual.Widgets[0].(*datadog.QueryValueWidget)
-	if !ok {
-		t.Fatalf("Widget type does not match: %v", actual.Widgets[0])
-	}
+	actualWidget := actual.Widgets[0].QueryValueWidget
 
 	assertEquals(t, "height", actualWidget.Height, expected.Height)
 	assertEquals(t, "width", actualWidget.Width, expected.Width)

--- a/integration_test/screen_widgets_test.go
+++ b/integration_test/screen_widgets_test.go
@@ -6,11 +6,148 @@ import (
 	"github.com/ojongerius/go-datadog-api"
 )
 
-/* TODO: Add tests for:
-* ToplistWidget
-* EventStreamWidget
-* ImageWidget
- */
+func TestToplistWidget(t *testing.T) {
+	board := createTestScreenboard(t)
+
+	expected := datadog.Widget{}.ToplistWidget
+	expected.X = 1
+	expected.Y = 1
+	expected.Width = 5
+	expected.Height = 5
+	expected.Type = "toplist"
+	expected.TitleText = "foo"
+	expected.TitleSize.Auto = false
+	expected.TitleSize.Size = 5
+	expected.TitleAlign = "center"
+	expected.Title = false
+	expected.Timeframe = "5m"
+	expected.Legend = false
+	expected.LegendSize = "5"
+
+	w := datadog.Widget{ToplistWidget: expected}
+
+	board.Widgets = append(board.Widgets, w)
+
+	if err := client.UpdateScreenboard(board); err != nil {
+		t.Fatalf("Updating a screenboard failed: %s", err)
+	}
+
+	actual, err := client.GetScreenboard(board.Id)
+	if err != nil {
+		t.Fatalf("Retreiving a screenboard failed: %s", err)
+	}
+
+	actualWidget := actual.Widgets[0].ToplistWidget
+
+	assertEquals(t, "x", actualWidget.X, expected.X)
+	assertEquals(t, "y", actualWidget.Y, expected.Y)
+	assertEquals(t, "height", actualWidget.Height, expected.Height)
+	assertEquals(t, "width", actualWidget.Width, expected.Width)
+	assertEquals(t, "title_text", actualWidget.TitleText, expected.TitleText)
+	assertEquals(t, "title_size", actualWidget.TitleSize, expected.TitleSize)
+	assertEquals(t, "title_align", actualWidget.TitleAlign, expected.TitleAlign)
+	assertEquals(t, "legend", actualWidget.Legend, expected.Legend)
+	assertEquals(t, "legend_size", actualWidget.LegendSize, expected.LegendSize)
+
+	cleanUpScreenboard(t, board.Id)
+}
+
+func TestEventSteamWidget(t *testing.T) {
+	board := createTestScreenboard(t)
+
+	expected := datadog.Widget{}.EventStreamWidget
+	expected.EventSize = "1"
+	expected.Width = 1
+	expected.Height = 1
+	expected.X = 1
+	expected.Y = 1
+	expected.Query = "foo"
+	expected.Timeframe = "5w"
+	expected.Title = false
+	expected.TitleAlign = "center"
+	expected.TitleSize.Auto = false
+	expected.TitleSize.Size = 5
+	expected.TitleText = "bar"
+	expected.Type = "baz"
+
+	w := datadog.Widget{EventStreamWidget: expected}
+
+	board.Widgets = append(board.Widgets, w)
+
+	if err := client.UpdateScreenboard(board); err != nil {
+		t.Fatalf("Updating a screenboard failed: %s", err)
+	}
+
+	actual, err := client.GetScreenboard(board.Id)
+	if err != nil {
+		t.Fatalf("Retreiving a screenboard failed: %s", err)
+	}
+
+	actualWidget := actual.Widgets[0].EventStreamWidget
+
+	assertEquals(t, "event_size", actualWidget.EventSize, expected.EventSize)
+	assertEquals(t, "width", actualWidget.Width, expected.Width)
+	assertEquals(t, "height", actualWidget.Height, expected.Height)
+	assertEquals(t, "x", actualWidget.X, expected.X)
+	assertEquals(t, "y", actualWidget.Y, expected.Y)
+	assertEquals(t, "query", actualWidget.Query, expected.Query)
+	assertEquals(t, "timeframe", actualWidget.Timeframe, expected.Timeframe)
+	assertEquals(t, "title", actualWidget.Title, expected.Title)
+	assertEquals(t, "title_align", actualWidget.TitleAlign, expected.TitleAlign)
+	assertEquals(t, "title_size", actualWidget.TitleSize, expected.TitleSize)
+	assertEquals(t, "title_text", actualWidget.TitleText, expected.TitleText)
+	assertEquals(t, "type", actualWidget.Type, expected.Type)
+
+	cleanUpScreenboard(t, board.Id)
+}
+
+func TestImageWidget(t *testing.T) {
+	board := createTestScreenboard(t)
+
+	expected := datadog.Widget{}.ImageWidget
+
+	expected.Width = 1
+	expected.Height = 1
+	expected.X = 1
+	expected.Y = 1
+	expected.Title = false
+	expected.TitleAlign = "center"
+	expected.TitleSize.Auto = false
+	expected.TitleSize.Size = 5
+	expected.TitleText = "bar"
+	expected.Type = "baz"
+	expected.Url = "qux"
+	expected.Sizing = "quuz"
+
+	w := datadog.Widget{ImageWidget: expected}
+
+	board.Widgets = append(board.Widgets, w)
+
+	if err := client.UpdateScreenboard(board); err != nil {
+		t.Fatalf("Updating a screenboard failed: %s", err)
+	}
+
+	actual, err := client.GetScreenboard(board.Id)
+	if err != nil {
+		t.Fatalf("Retreiving a screenboard failed: %s", err)
+	}
+
+	actualWidget := actual.Widgets[0].ImageWidget
+
+	assertEquals(t, "width", actualWidget.Width, expected.Width)
+	assertEquals(t, "height", actualWidget.Height, expected.Height)
+	assertEquals(t, "x", actualWidget.X, expected.X)
+	assertEquals(t, "y", actualWidget.Y, expected.Y)
+	assertEquals(t, "title", actualWidget.Title, expected.Title)
+	assertEquals(t, "title_align", actualWidget.TitleAlign, expected.TitleAlign)
+	assertEquals(t, "title_size", actualWidget.TitleSize, expected.TitleSize)
+	assertEquals(t, "title_text", actualWidget.TitleText, expected.TitleText)
+	assertEquals(t, "type", actualWidget.Type, expected.Type)
+	assertEquals(t, "url", actualWidget.Url, expected.Url)
+	assertEquals(t, "sizing", actualWidget.Sizing, expected.Sizing)
+
+	cleanUpScreenboard(t, board.Id)
+}
 
 func TestFreeTextWidget(t *testing.T) {
 	board := createTestScreenboard(t)

--- a/integration_test/screen_widgets_test.go
+++ b/integration_test/screen_widgets_test.go
@@ -3,7 +3,7 @@ package integration_test
 import (
 	"testing"
 
-	"github.com/ojongerius/go-datadog-api"
+	"github.com/zorkian/go-datadog-api"
 )
 
 func TestAlertValueWidget(t *testing.T) {

--- a/integration_test/screenboards_test.go
+++ b/integration_test/screenboards_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/seiffert/go-datadog-api"
+	"github.com/ojongerius/go-datadog-api"
 )
 
 var (
@@ -15,11 +15,11 @@ var (
 )
 
 func init() {
-	apiKey = os.Getenv("DD_API_KEY")
-	appKey = os.Getenv("DD_APP_KEY")
+	apiKey = os.Getenv("DATADOG_API_KEY")
+	appKey = os.Getenv("DATADOG_APP_KEY")
 
 	if apiKey == "" || appKey == "" {
-		log.Fatal("Please make sure to set the env variables 'DD_API_KEY' and 'DD_APP_KEY' before running this test")
+		log.Fatal("Please make sure to set the env variables 'DATADOG_API_KEY' and 'DATADOG_APP_KEY' before running this test")
 	}
 
 	client = datadog.NewClient(apiKey, appKey)
@@ -96,8 +96,8 @@ func TestGetScreenboards(t *testing.T) {
 func getTestScreenboard() *datadog.Screenboard {
 	return &datadog.Screenboard{
 		Title:   "___Test-Board___",
-		Height:  600,
-		Width:   800,
+		Height:  "600",
+		Width:   "800",
 		Widgets: []datadog.Widget{},
 	}
 }

--- a/integration_test/screenboards_test.go
+++ b/integration_test/screenboards_test.go
@@ -55,6 +55,30 @@ func TestCreateAndDeleteScreenboard(t *testing.T) {
 	cleanUpScreenboard(t, actual.Id)
 }
 
+func TestShareAndRevokeScreenboard(t *testing.T) {
+	expected := getTestScreenboard()
+	// create the screenboard
+	actual, err := client.CreateScreenboard(expected)
+	if err != nil {
+		t.Fatalf("Creating a screenboard failed when it shouldn't: %s", err)
+	}
+
+	// share screenboard and verify it was shared
+	var response datadog.ScreenShareResponse
+	err = client.ShareScreenboard(actual.Id, &response)
+	if err != nil {
+		t.Fatalf("Failed to share screenboard: %s", err)
+	}
+
+	// revoke screenboard
+	err = client.RevokeScreenboard(actual.Id)
+	if err != nil {
+		t.Fatalf("Failed to revoke sharing of screenboard: %s", err)
+	}
+
+	cleanUpScreenboard(t, response.BoardId)
+}
+
 func TestUpdateScreenboard(t *testing.T) {
 	board := createTestScreenboard(t)
 

--- a/integration_test/screenboards_test.go
+++ b/integration_test/screenboards_test.go
@@ -141,10 +141,10 @@ func assertScreenboardEquals(t *testing.T, actual, expected *datadog.Screenboard
 		t.Errorf("Screenboard title does not match: %s != %s", actual.Title, expected.Title)
 	}
 	if actual.Width != expected.Width {
-		t.Errorf("Screenboard width does not match: %d != %d", actual.Width, expected.Width)
+		t.Errorf("Screenboard width does not match: %s != %s", actual.Width, expected.Width)
 	}
 	if actual.Height != expected.Height {
-		t.Errorf("Screenboard width does not match: %d != %d", actual.Height, expected.Height)
+		t.Errorf("Screenboard width does not match: %s != %s", actual.Height, expected.Height)
 	}
 	if len(actual.Widgets) != len(expected.Widgets) {
 		t.Errorf("Number of Screenboard widgets does not match: %d != %d", len(actual.Widgets), len(expected.Widgets))

--- a/integration_test/screenboards_test.go
+++ b/integration_test/screenboards_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ojongerius/go-datadog-api"
+	"github.com/zorkian/go-datadog-api"
 )
 
 var (

--- a/screen_widgets.go
+++ b/screen_widgets.go
@@ -26,6 +26,25 @@ type TileDefEvent struct {
 	Query string `json:"q"`
 }
 
+type AlertValueWidget struct {
+	TitleSize    int    `json:"title_size"`
+	Title        bool   `json:"title"`
+	TitleAlign   string `json:"title_align"`
+	TextAlign    string `json:"text_align"`
+	TitleText    string `json:"title_text"`
+	Precision    int    `json:"precision"`
+	AlertId      int    `json:"alert_id"`
+	Timeframe    string `json:"timeframe"`
+	AddTimeframe bool   `json:"add_timeframe"`
+	Y            int    `json:"y"`
+	X            int    `json:"x"`
+	TextSize     string `json:"text_size"`
+	Height       int    `json:"height"`
+	Width        int    `json:"width"`
+	Type         string `json:"type"`
+	Unit         string `json:"unit"`
+}
+
 type ChangeWidget struct {
 	TitleSize  int     `json:"title_size"`
 	Title      bool    `json:"title"`
@@ -50,7 +69,7 @@ type GraphWidget struct {
 	Y          int     `json:"x"`
 	Type       string  `json:"type"`
 	Timeframe  string  `json:"timeframe"`
-	LegendSize string  `json:"legend_size"`
+	LegendSize int     `json:"legend_size"`
 	Legend     bool    `json:"legend"`
 	TileDef    TileDef `json:"tile_def"`
 }
@@ -67,24 +86,6 @@ type EventTimelineWidget struct {
 	Type       string `json:"type"`
 	Timeframe  string `json:"timeframe"`
 	Query      string `json:"query"`
-}
-
-type AlertValueWidget struct {
-	TitleSize    int    `json:"title_size"`
-	Title        bool   `json:"title"`
-	TitleAlign   string `json:"title_align"`
-	TitleText    string `json:"title_text"`
-	Height       int    `json:"height"`
-	Width        int    `json:"width"`
-	X            int    `json:"y"`
-	Y            int    `json:"x"`
-	Precision    int    `json:"precision"`
-	AlertId      int    `json:"alert_id"`
-	Timeframe    string `json:"timeframe"`
-	Type         string `json:"type"`
-	AddTimeframe bool   `json:"add_timeframe"`
-	TextSize     string `json:"text_size"`
-	Unit         string `json:"auto"`
 }
 
 type AlertGraphWidget struct {
@@ -114,7 +115,7 @@ type HostMapWidget struct {
 	Y          int     `json:"x"`
 	Query      string  `json:"query"`
 	Timeframe  string  `json:"timeframe"`
-	LegendSize string  `json:"legend_size"`
+	LegendSize int     `json:"legend_size"`
 	Type       string  `json:"type"`
 	Legend     bool    `json:"legend"`
 	TileDef    TileDef `json:"tile_def"`
@@ -224,7 +225,7 @@ type ConditionalFormat struct {
 type ToplistWidget struct {
 	Height     int      `json:"height"`
 	Legend     bool     `json:"legend"`
-	LegendSize string   `json:"legend_size"`
+	LegendSize int      `json:"legend_size"`
 	TileDef    TileDef  `json:"tile_def"`
 	Timeframe  string   `json:"timeframe"`
 	Title      bool     `json:"title"`

--- a/screen_widgets.go
+++ b/screen_widgets.go
@@ -5,31 +5,6 @@ import (
 	"strconv"
 )
 
-type Widget interface{}
-
-func NewTimeseriesWidget(
-	x, y, width, height int,
-	title bool, titleAlign string, titleSize TextSize, titleText string,
-	timeframe string,
-	requests []TimeseriesRequest) Widget {
-	return &TimeseriesWidget{
-		X:          x,
-		Y:          y,
-		Width:      width,
-		Height:     height,
-		Title:      title,
-		TitleAlign: titleAlign,
-		TitleSize:  titleSize,
-		TitleText:  titleText,
-		Timeframe:  timeframe,
-		TileDef: TileDef{
-			Viz:      "timeseries",
-			Requests: requests,
-		},
-		Type: "timeseries",
-	}
-}
-
 type TimeseriesWidget struct {
 	Height     int      `json:"height"`
 	Legend     bool     `json:"legend"`
@@ -100,31 +75,6 @@ type TileDefEvent struct {
 	Query string `json:"q"`
 }
 
-func NewQueryValueWidget(
-	x, y, width, height int,
-	title bool, titleAlign string, titleSize TextSize, titleText,
-	textAlign string, textSize TextSize,
-	timeframe, timeframeAggregator,
-	aggregator, query string) Widget {
-	return &QueryValueWidget{
-		X:                   x,
-		Y:                   y,
-		Width:               width,
-		Height:              height,
-		Title:               title,
-		TitleAlign:          titleAlign,
-		TitleSize:           titleSize,
-		TitleText:           titleText,
-		TextAlign:           textAlign,
-		TextSize:            textSize,
-		Timeframe:           timeframe,
-		TimeframeAggregator: timeframeAggregator,
-		Aggregator:          aggregator,
-		Query:               query,
-		Type:                "query_value",
-	}
-}
-
 type QueryValueWidget struct {
 	Timeframe           string              `json:"timeframe"`
 	TimeframeAggregator string              `json:"aggr"`
@@ -158,29 +108,6 @@ type ConditionalFormat struct {
 	Value      int    `json:"value"`
 }
 
-func NewToplistWidget(
-	x, y, width, height int,
-	title bool, titleAlign string, titleSize TextSize, titleText string,
-	timeframe string,
-	request TimeseriesRequest) Widget {
-	return &ToplistWidget{
-		X:          x,
-		Y:          y,
-		Width:      width,
-		Height:     height,
-		Title:      title,
-		TitleAlign: titleAlign,
-		TitleSize:  titleSize,
-		TitleText:  titleText,
-		TileDef: TileDef{
-			Viz:      "toplist",
-			Requests: []TimeseriesRequest{request},
-		},
-		Timeframe: timeframe,
-		Type:      "toplist",
-	}
-}
-
 type ToplistWidget struct {
 	Height     int      `json:"height"`
 	Legend     bool     `json:"legend"`
@@ -195,27 +122,6 @@ type ToplistWidget struct {
 	Width      int      `json:"width"`
 	X          int      `json:"x"`
 	Y          int      `json:"y"`
-}
-
-func NewEventStreamWidget(
-	x, y, width, height int,
-	title bool, titleAlign string, titleSize TextSize, titleText string,
-	timeframe string,
-	query, eventSize string) Widget {
-	return &EventStreamWidget{
-		X:          x,
-		Y:          y,
-		Width:      width,
-		Height:     height,
-		Title:      title,
-		TitleAlign: titleAlign,
-		TitleSize:  titleSize,
-		TitleText:  titleText,
-		Timeframe:  timeframe,
-		Query:      query,
-		EventSize:  eventSize,
-		Type:       "event_stream",
-	}
 }
 
 type EventStreamWidget struct {
@@ -233,19 +139,6 @@ type EventStreamWidget struct {
 	Y          int      `json:"y"`
 }
 
-func NewFreeTextWidget(x, y, width, height int, text string, size int, align string) Widget {
-	return &FreeTextWidget{
-		X:         x,
-		Y:         y,
-		Width:     width,
-		Height:    height,
-		Text:      text,
-		FontSize:  fmt.Sprintf("%d", size),
-		TextAlign: align,
-		Type:      "free_text",
-	}
-}
-
 type FreeTextWidget struct {
 	Color     string `json:"color,omitempty"`
 	FontSize  string `json:"font_size,omitempty"`
@@ -256,22 +149,6 @@ type FreeTextWidget struct {
 	Width     int    `json:"width"`
 	X         int    `json:"x"`
 	Y         int    `json:"y"`
-}
-
-func NewImageWidget(x, y, width, height int, sizing, url string, title bool, titleAlign string, titleSize TextSize, titleText string,
-) Widget {
-	return &ImageWidget{
-		X:          x,
-		Y:          y,
-		Width:      width,
-		Height:     height,
-		Type:       "image",
-		Title:      title,
-		TitleAlign: titleAlign,
-		TitleSize:  titleSize,
-		TitleText:  titleText,
-		Url:        url,
-	}
 }
 
 type ImageWidget struct {

--- a/screen_widgets.go
+++ b/screen_widgets.go
@@ -1,10 +1,5 @@
 package datadog
 
-import (
-	"fmt"
-	"strconv"
-)
-
 type TimeseriesWidget struct {
 	Height     int      `json:"height"`
 	Legend     bool     `json:"legend"`
@@ -25,39 +20,10 @@ type TextSize struct {
 	Auto bool
 }
 
-func (size *TextSize) UnmarshalJSON(data []byte) error {
-	if string(data) == "\"auto\"" {
-		size.Auto = true
-		return nil
-	}
-
-	num, err := strconv.Atoi(string(data))
-	if err != nil {
-		return err
-	}
-	size.Size = num
-
-	return nil
-}
-func (size *TextSize) MarshalJSON() ([]byte, error) {
-	if size.Auto {
-		return []byte("\"auto\""), nil
-	}
-
-	return []byte(fmt.Sprintf("%d", size.Size)), nil
-}
-
 type TileDef struct {
 	Events   []TileDefEvent      `json:"events"`
 	Requests []TimeseriesRequest `json:"requests"`
 	Viz      string              `json:"viz"`
-}
-
-func NewTimeseriesRequest(rtype string, query string) TimeseriesRequest {
-	return TimeseriesRequest{
-		Query: query,
-		Type:  rtype,
-	}
 }
 
 type TimeseriesRequest struct {

--- a/screen_widgets.go
+++ b/screen_widgets.go
@@ -1,20 +1,5 @@
 package datadog
 
-type TimeseriesWidget struct {
-	Height     int      `json:"height"`
-	Legend     bool     `json:"legend"`
-	TileDef    TileDef  `json:"tile_def"`
-	Timeframe  string   `json:"timeframe"`
-	Title      bool     `json:"title"`
-	TitleAlign string   `json:"title_align"`
-	TitleSize  TextSize `json:"title_size"`
-	TitleText  string   `json:"title_text"`
-	Type       string   `json:"type"`
-	Width      int      `json:"width"`
-	X          int      `json:"x"`
-	Y          int      `json:"y"`
-}
-
 type TextSize struct {
 	Size int
 	Auto bool
@@ -39,6 +24,168 @@ type TimeseriesRequestStyle struct {
 
 type TileDefEvent struct {
 	Query string `json:"q"`
+}
+
+type ChangeWidget struct {
+	TitleSize  int     `json:"title_size"`
+	Title      bool    `json:"title"`
+	TitleAlign string  `json:"title_align"`
+	TitleText  string  `json:"title_text"`
+	Height     int     `json:"height"`
+	Width      int     `json:"width"`
+	X          int     `json:"y"`
+	Y          int     `json:"x"`
+	Aggregator string  `json:"aggregator"`
+	TileDef    TileDef `json:"tile_def"`
+}
+
+type GraphWidget struct {
+	TitleSize  int     `json:"title_size"`
+	Title      bool    `json:"title"`
+	TitleAlign string  `json:"title_align"`
+	TitleText  string  `json:"title_text"`
+	Height     int     `json:"height"`
+	Width      int     `json:"width"`
+	X          int     `json:"y"`
+	Y          int     `json:"x"`
+	Type       string  `json:"type"`
+	Timeframe  string  `json:"timeframe"`
+	LegendSize string  `json:"legend_size"`
+	Legend     bool    `json:"legend"`
+	TileDef    TileDef `json:"tile_def"`
+}
+
+type EventTimelineWidget struct {
+	TitleSize  int    `json:"title_size"`
+	Title      bool   `json:"title"`
+	TitleAlign string `json:"title_align"`
+	TitleText  string `json:"title_text"`
+	Height     int    `json:"height"`
+	Width      int    `json:"width"`
+	X          int    `json:"y"`
+	Y          int    `json:"x"`
+	Type       string `json:"type"`
+	Timeframe  string `json:"timeframe"`
+	Query      string `json:"query"`
+}
+
+type AlertValueWidget struct {
+	TitleSize    int    `json:"title_size"`
+	Title        bool   `json:"title"`
+	TitleAlign   string `json:"title_align"`
+	TitleText    string `json:"title_text"`
+	Height       int    `json:"height"`
+	Width        int    `json:"width"`
+	X            int    `json:"y"`
+	Y            int    `json:"x"`
+	Precision    int    `json:"precision"`
+	AlertId      int    `json:"alert_id"`
+	Timeframe    string `json:"timeframe"`
+	Type         string `json:"type"`
+	AddTimeframe bool   `json:"add_timeframe"`
+	TextSize     string `json:"text_size"`
+	Unit         string `json:"auto"`
+}
+
+type AlertGraphWidget struct {
+	TitleSize    int    `json:"title_size"`
+	VizType      string `json:"timeseries"`
+	Title        bool   `json:"title"`
+	TitleAlign   string `json:"title_align"`
+	TitleText    string `json:"title_text"`
+	Height       int    `json:"height"`
+	Width        int    `json:"width"`
+	X            int    `json:"y"`
+	Y            int    `json:"x"`
+	AlertId      int    `json:"alert_id"`
+	Timeframe    string `json:"timeframe"`
+	Type         string `json:"type"`
+	AddTimeframe bool   `json:"add_timeframe"`
+}
+
+type HostMapWidget struct {
+	TitleSize  int     `json:"title_size"`
+	Title      bool    `json:"title"`
+	TitleAlign string  `json:"title_align"`
+	TitleText  string  `json:"title_text"`
+	Height     int     `json:"height"`
+	Width      int     `json:"width"`
+	X          int     `json:"y"`
+	Y          int     `json:"x"`
+	Query      string  `json:"query"`
+	Timeframe  string  `json:"timeframe"`
+	LegendSize string  `json:"legend_size"`
+	Type       string  `json:"type"`
+	Legend     bool    `json:"legend"`
+	TileDef    TileDef `json:"tile_def"`
+}
+
+type CheckStatusWidget struct {
+	TitleSize        int    `json:"title_size"`
+	Title            bool   `json:"title"`
+	TitleAlign       string `json:"title_align"`
+	TextAlign        string `json:"text_align"`
+	CheckStatusTitle string `json:"title_text"`
+	Height           int    `json:"height"`
+	Width            int    `json:"width"`
+	X                int    `json:"y"`
+	Y                int    `json:"x"`
+	Tags             string `json:"tags"`
+	Timeframe        string `json:"timeframe"`
+	TextSize         string `json:"text_size"`
+	CheckStatus      string `json:"type"`
+	Check            string `json:"check"`
+	Group            string `json:"group"`
+	Grouping         string `json:"grouping"`
+}
+
+type IFrameWidget struct {
+	TitleSize  int    `json:"title_size"`
+	Title      bool   `json:"title"`
+	Url        string `json:"url"`
+	TitleAlign string `json:"title_align"`
+	TitleText  string `json:"title_text"`
+	Height     int    `json:"height"`
+	Width      int    `json:"width"`
+	X          int    `json:"y"`
+	Y          int    `json:"x"`
+	IFrame     string `json:"type"`
+}
+
+type NoteWidget struct {
+	TitleSize    int    `json:"title_size"`
+	Title        bool   `json:"title"`
+	RefreshEvery int    `json:"refresh_every"`
+	TickPos      string `json:"tick_pos"`
+	TitleAlign   string `json:"title_align"`
+	TickEdge     string `json:"tick_edge"`
+	TextAlign    string `json:"text_align"`
+	TitleText    string `json:"title_text"`
+	Height       int    `json:"height"`
+	Color        string `json:"bgcolor"`
+	Html         string `json:"html"`
+	Y            int    `json:"y"`
+	X            int    `json:"x"`
+	FontSize     int    `json:"font_size"`
+	Tick         bool   `json:"tick"`
+	Note         string `json:"type"`
+	With         int    `json:"width"`
+	AutoRefresh  bool   `json:"auto_refresh"`
+}
+
+type TimeseriesWidget struct {
+	Height     int      `json:"height"`
+	Legend     bool     `json:"legend"`
+	TileDef    TileDef  `json:"tile_def"`
+	Timeframe  string   `json:"timeframe"`
+	Title      bool     `json:"title"`
+	TitleAlign string   `json:"title_align"`
+	TitleSize  TextSize `json:"title_size"`
+	TitleText  string   `json:"title_text"`
+	Type       string   `json:"type"`
+	Width      int      `json:"width"`
+	X          int      `json:"x"`
+	Y          int      `json:"y"`
 }
 
 type QueryValueWidget struct {

--- a/screen_widgets.go
+++ b/screen_widgets.go
@@ -82,7 +82,7 @@ type QueryValueWidget struct {
 	CalcFunc            string              `json:"calc_func"`
 	ConditionalFormats  []ConditionalFormat `json:"conditional_formats"`
 	Height              int                 `json:"height"`
-	IsValidQuery        bool                `json:is_valid_query,omitempty"`
+	IsValidQuery        bool                `json:"is_valid_query,omitempty"`
 	Metric              string              `json:"metric"`
 	MetricType          string              `json:"metric_type"`
 	Precision           int                 `json:"precision"`

--- a/screen_widgets.go
+++ b/screen_widgets.go
@@ -121,22 +121,22 @@ type HostMapWidget struct {
 }
 
 type CheckStatusWidget struct {
-	TitleSize        int    `json:"title_size"`
-	Title            bool   `json:"title"`
-	TitleAlign       string `json:"title_align"`
-	TextAlign        string `json:"text_align"`
-	CheckStatusTitle string `json:"title_text"`
-	Height           int    `json:"height"`
-	Width            int    `json:"width"`
-	X                int    `json:"y"`
-	Y                int    `json:"x"`
-	Tags             string `json:"tags"`
-	Timeframe        string `json:"timeframe"`
-	TextSize         string `json:"text_size"`
-	CheckStatus      string `json:"type"`
-	Check            string `json:"check"`
-	Group            string `json:"group"`
-	Grouping         string `json:"grouping"`
+	TitleSize  int    `json:"title_size"`
+	Title      bool   `json:"title"`
+	TitleAlign string `json:"title_align"`
+	TextAlign  string `json:"text_align"`
+	TitleText  string `json:"title_text"`
+	Height     int    `json:"height"`
+	Width      int    `json:"width"`
+	X          int    `json:"y"`
+	Y          int    `json:"x"`
+	Tags       string `json:"tags"`
+	Timeframe  string `json:"timeframe"`
+	TextSize   string `json:"text_size"`
+	Type       string `json:"type"`
+	Check      string `json:"check"`
+	Group      string `json:"group"`
+	Grouping   string `json:"grouping"`
 }
 
 type IFrameWidget struct {
@@ -149,7 +149,7 @@ type IFrameWidget struct {
 	Width      int    `json:"width"`
 	X          int    `json:"y"`
 	Y          int    `json:"x"`
-	IFrame     string `json:"type"`
+	Type       string `json:"type"`
 }
 
 type NoteWidget struct {
@@ -169,7 +169,7 @@ type NoteWidget struct {
 	FontSize     int    `json:"font_size"`
 	Tick         bool   `json:"tick"`
 	Note         string `json:"type"`
-	With         int    `json:"width"`
+	Width        int    `json:"width"`
 	AutoRefresh  bool   `json:"auto_refresh"`
 }
 

--- a/screenboards.go
+++ b/screenboards.go
@@ -35,7 +35,7 @@ type Widget struct {
 	EventStreamWidget EventStreamWidget `json:"event_stream"`
 	FreeTextWidget    FreeTextWidget    `json:"free_text"`
 	ToplistWidget     ToplistWidget     `json:"toplist"`
-	ImageWidget       ImageWidget       `json:"image`
+	ImageWidget       ImageWidget       `json:"image"`
 }
 
 // ScreenboardLite represents a user created screenboard. This is the mini

--- a/screenboards.go
+++ b/screenboards.go
@@ -100,3 +100,18 @@ func (self *Client) CreateScreenboard(board *Screenboard) (*Screenboard, error) 
 func (self *Client) UpdateScreenboard(board *Screenboard) error {
 	return self.doJsonRequest("PUT", fmt.Sprintf("/v1/screen/%d", board.Id), board, nil)
 }
+
+type ScreenShareResponse struct {
+	BoardId   int    `json:"board_id"`
+	PublicUrl string `json:"public_url"`
+}
+
+// ShareScreenboard shares an existing screenboard, it takes and updates ScreenShareResponse
+func (self *Client) ShareScreenboard(id int, response *ScreenShareResponse) error {
+	return self.doJsonRequest("GET", fmt.Sprintf("/v1/screen/share/%d", id), nil, response)
+}
+
+// RevokeScreenboard revokes a currently shared screenboard
+func (self *Client) RevokeScreenboard(id int) error {
+	return self.doJsonRequest("DELETE", fmt.Sprintf("/v1/screen/share/%d", id), nil, nil)
+}

--- a/screenboards.go
+++ b/screenboards.go
@@ -9,7 +9,6 @@
 package datadog
 
 import (
-	"encoding/json"
 	"fmt"
 )
 
@@ -25,81 +24,18 @@ type Screenboard struct {
 	TemplateVariables []TemplateVariable `json:"template_variables,omitempty"`
 	Widgets           []Widget           `json:"widgets"`
 }
-type TemplateVariable struct {
-	Default string `json:"default"`
-	Name    string `json:"name"`
-	Prefix  string `json:"prefix"`
-}
 
-func (s *Screenboard) UnmarshalJSON(data []byte) error {
-	dest := struct {
-		Id                int                `json:"id"`
-		Title             string             `json:"board_title"`
-		Height            json.RawMessage    `json:"height"`
-		Width             json.RawMessage    `json:"width"`
-		Shared            bool               `json:"shared"`
-		Templated         bool               `json:"templated"`
-		TemplateVariables []TemplateVariable `json:"template_variables"`
-		Widgets           []json.RawMessage  `json:"widgets"`
-	}{}
-	err := json.Unmarshal(data, &dest)
-	if err != nil {
-		return err
-	}
-
-	widgets := []Widget{}
-	for _, rawWidget := range dest.Widgets {
-		typeStruct := struct {
-			Type string `json:"type"`
-		}{}
-		if err := json.Unmarshal(rawWidget, &typeStruct); err != nil {
-			return fmt.Errorf("Could not detect widget type: %s", err)
-		}
-
-		widget, err := unmarshalWidget(typeStruct.Type, rawWidget)
-		if err != nil {
-			return fmt.Errorf("Could not unmarshal widget (type %s): %s", typeStruct.Type, err)
-		}
-
-		widgets = append(widgets, widget)
-	}
-
-	s.Id = dest.Id
-	s.Title = dest.Title
-	s.Height = string(dest.Height)
-	s.Width = string(dest.Width)
-	s.Shared = dest.Shared
-	s.Templated = dest.Templated
-	s.TemplateVariables = dest.TemplateVariables
-	s.Widgets = widgets
-
-	return nil
-}
-func unmarshalWidget(widgetType string, data json.RawMessage) (Widget, error) {
-	var dest Widget
-
-	switch widgetType {
-	case "timeseries":
-		dest = &TimeseriesWidget{}
-	case "query_value":
-		dest = &QueryValueWidget{}
-	case "event_stream":
-		dest = &EventStreamWidget{}
-	case "free_text":
-		dest = &FreeTextWidget{}
-	case "toplist":
-		dest = &ToplistWidget{}
-	case "image":
-		dest = &ImageWidget{}
-	default:
-		return nil, fmt.Errorf("Could not unmarshal unknown widget type %s.", widgetType)
-	}
-
-	if err := json.Unmarshal(data, dest); err != nil {
-		return nil, err
-	}
-
-	return dest, nil
+//type Widget struct {
+type Widget struct {
+	Default 		  string `json:"default"`
+	Name              string `json:"name"`
+	Prefix            string `json:"prefix"`
+	TimeseriesWidget  string `json:"timeseries"`
+	QueryValueWidget  string `json:"query_value"`
+	EventStreamWidget string `json:"event_stream"`
+	FreeTextWidget 	  string `json:"free_text"`
+	ToplistWidget     string `json:"toplist"`
+	ImageWidget       string `json:"image`
 }
 
 // ScreenboardLite represents a user created screenboard. This is the mini

--- a/screenboards.go
+++ b/screenboards.go
@@ -27,15 +27,24 @@ type Screenboard struct {
 
 //type Widget struct {
 type Widget struct {
-	Default           string            `json:"default"`
-	Name              string            `json:"name"`
-	Prefix            string            `json:"prefix"`
-	TimeseriesWidget  TimeseriesWidget  `json:"timeseries"`
-	QueryValueWidget  QueryValueWidget  `json:"query_value"`
-	EventStreamWidget EventStreamWidget `json:"event_stream"`
-	FreeTextWidget    FreeTextWidget    `json:"free_text"`
-	ToplistWidget     ToplistWidget     `json:"toplist"`
-	ImageWidget       ImageWidget       `json:"image"`
+	Default             string              `json:"default"`
+	Name                string              `json:"name"`
+	Prefix              string              `json:"prefix"`
+	TimeseriesWidget    TimeseriesWidget    `json:"timeseries"`
+	QueryValueWidget    QueryValueWidget    `json:"query_value"`
+	EventStreamWidget   EventStreamWidget   `json:"event_stream"`
+	FreeTextWidget      FreeTextWidget      `json:"free_text"`
+	ToplistWidget       ToplistWidget       `json:"toplist"`
+	ImageWidget         ImageWidget         `json:"image"`
+	ChangeWidget        ChangeWidget        `json:"change"`
+	GraphWidget         GraphWidget         `json:"graph"`
+	EventTimelineWidget EventTimelineWidget `json:"event_timeline"`
+	AlertValueWidget    AlertValueWidget    `json:"alert_value"`
+	AlertGraphWidget    AlertGraphWidget    `json:"alert_graph"`
+	HostMapWidget       HostMapWidget       `json:"hostmap"`
+	CheckStatusWidget   CheckStatusWidget   `json:"check_status"`
+	IFrameWidget        IFrameWidget        `json:"iframe"`
+	NoteWidget          NoteWidget          `json:"frame"`
 }
 
 // ScreenboardLite represents a user created screenboard. This is the mini

--- a/screenboards.go
+++ b/screenboards.go
@@ -27,15 +27,15 @@ type Screenboard struct {
 
 //type Widget struct {
 type Widget struct {
-	Default 		  string `json:"default"`
-	Name              string `json:"name"`
-	Prefix            string `json:"prefix"`
-	TimeseriesWidget  string `json:"timeseries"`
-	QueryValueWidget  string `json:"query_value"`
-	EventStreamWidget string `json:"event_stream"`
-	FreeTextWidget 	  string `json:"free_text"`
-	ToplistWidget     string `json:"toplist"`
-	ImageWidget       string `json:"image`
+	Default 		  string 			`json:"default"`
+	Name              string 			`json:"name"`
+	Prefix            string 			`json:"prefix"`
+	TimeseriesWidget  TimeseriesWidget  `json:"timeseries"`
+	QueryValueWidget  QueryValueWidget  `json:"query_value"`
+	EventStreamWidget EventStreamWidget `json:"event_stream"`
+	FreeTextWidget 	  FreeTextWidget  	`json:"free_text"`
+	ToplistWidget     ToplistWidget 	`json:"toplist"`
+	ImageWidget       ImageWidget		`json:"image`
 }
 
 // ScreenboardLite represents a user created screenboard. This is the mini

--- a/screenboards.go
+++ b/screenboards.go
@@ -27,15 +27,15 @@ type Screenboard struct {
 
 //type Widget struct {
 type Widget struct {
-	Default 		  string 			`json:"default"`
-	Name              string 			`json:"name"`
-	Prefix            string 			`json:"prefix"`
+	Default           string            `json:"default"`
+	Name              string            `json:"name"`
+	Prefix            string            `json:"prefix"`
 	TimeseriesWidget  TimeseriesWidget  `json:"timeseries"`
 	QueryValueWidget  QueryValueWidget  `json:"query_value"`
 	EventStreamWidget EventStreamWidget `json:"event_stream"`
-	FreeTextWidget 	  FreeTextWidget  	`json:"free_text"`
-	ToplistWidget     ToplistWidget 	`json:"toplist"`
-	ImageWidget       ImageWidget		`json:"image`
+	FreeTextWidget    FreeTextWidget    `json:"free_text"`
+	ToplistWidget     ToplistWidget     `json:"toplist"`
+	ImageWidget       ImageWidget       `json:"image`
 }
 
 // ScreenboardLite represents a user created screenboard. This is the mini


### PR DESCRIPTION
Hey there.

Raising a PR sooner rather than later. AFAICS this ready to merge, but I could use some fresh eyes.

I'm super happy with @seiffert's tests :smiley: Creating them boost confidence in change, and am very much in favour for having them in place for all resources.

Output of acceptance tests: 

```sh
✘ ojongerius@hipster  ~/gocode/src/github.com/ojongerius/go-datadog-api   screenboards ●  make testacc
TF_ACC=1 go test integration_test/* -v  -timeout 90m
=== RUN TestAlertValueWidget
--- PASS: TestAlertValueWidget (5.09s)
=== RUN TestChangeWidget
--- PASS: TestChangeWidget (6.14s)
=== RUN TestGraphWidget
--- PASS: TestGraphWidget (5.73s)
=== RUN TestEventTimelineWidget
--- PASS: TestEventTimelineWidget (5.70s)
=== RUN TestAlertGraphWidget
--- PASS: TestAlertGraphWidget (5.50s)
=== RUN TestHostMapWidget
--- PASS: TestHostMapWidget (5.79s)
=== RUN TestCheckStatusWidget
--- PASS: TestCheckStatusWidget (5.70s)
=== RUN TestIFrameWidget
--- PASS: TestIFrameWidget (5.89s)
=== RUN TestNoteWidget
--- PASS: TestNoteWidget (5.20s)
=== RUN TestToplistWidget
--- PASS: TestToplistWidget (6.70s)
=== RUN TestEventSteamWidget
--- PASS: TestEventSteamWidget (9.01s)
=== RUN TestImageWidget
--- PASS: TestImageWidget (5.55s)
=== RUN TestFreeTextWidget
--- PASS: TestFreeTextWidget (5.38s)
=== RUN TestTimeseriesWidget
--- PASS: TestTimeseriesWidget (5.47s)
=== RUN TestQueryValueWidget
--- PASS: TestQueryValueWidget (9.69s)
=== RUN TestCreateAndDeleteScreenboard
--- PASS: TestCreateAndDeleteScreenboard (3.53s)
=== RUN TestShareAndRevokeScreenboard
--- PASS: TestShareAndRevokeScreenboard (5.30s)
=== RUN TestUpdateScreenboard
--- PASS: TestUpdateScreenboard (5.34s)
=== RUN TestGetScreenboards
--- PASS: TestGetScreenboards (5.23s)
PASS
ok  	command-line-arguments	116.219s
```

##### Additions
* Travis suppport to check `gofmt`, run `golint` (not enforcing anything), `go vet`, and normal tests.
* Makefile to improve devspeed, run `make test`, to run normal tests, `make testacc` for integration tests, and more. See README.
* README.md changes to inform users of these conveniences. 
* Tests and support for things that were still open (and a few extra) in @seiffert's PR #7:
  * Sharing and revoking of Screenboards 
  * `EventTimelineWidget`, `ImageWidget`, `NoteWidget`, `AlertGraphWidget`, `AlertValueWidget`, `IFrameWidget`, `CheckStatusWidget`, `GraphWidget`, `ChangeWidget`, `HostmapWidget`

##### Removals
I've removed the widget constructors @seiffert added in e7b5df642f9d40cd391c602d133dbcefa8f717f4. They added complexity I did not like for features I would not use. If others want those features they are welcome to implement them. This should be possible without breaking the API. Correct me if I'm wrong.

##### Shortcuts
I've skipped testing ConditionalFormat because of time constraints. I'm tempted to raise a (tech debt) issue for others (or a future me) later in time.

I noticed @seiffert added `omittrue` to some of the structs. Ie:

`
	TemplateVariables []TemplateVariable `json:"template_variables,omitempty"`
`

Which is awesome. I think this could be done for many of the structs, but I found it too time consuming. Maybe we should raise a tech debt issue for that one. Or just wait for people to implement this when needed. I can see myself doing this when I starting using the Screenboard features myself.

##### Todo
- [x] Update imports
- [x] @zorkian to enable Travis for go-datadog-api
- [x] Update Travis link in README
- [ ] Raise tech debt issue to add test for other resources
- [ ] Raise tech debt issue to review/add omittrue to structs