### PR TITLE
Add query metrics method

### DIFF
--- a/series.go
+++ b/series.go
@@ -8,6 +8,8 @@
 
 package datadog
 
+import "strconv"
+
 // DataPoint is a tuple of [UNIX timestamp, value]. This has to use floats
 // because the value could be non-integer.
 type DataPoint [2]float64
@@ -22,14 +24,44 @@ type Metric struct {
 	Tags   []string    `json:"tags,omitempty"`
 }
 
+// Series represents a collection of data points we get when we query for timeseries data
+type Series struct {
+	Metric      string      `json:"metric,omitempty"`
+	DisplayName string      `json:"display_name,omitempty"`
+	Points      []DataPoint `json:"pointlist,omitempty"`
+	Start       float64     `json:"start,omitempty"`
+	End         float64     `json:"end,omitempty"`
+	Interval    int         `json:"interval,omitempty"`
+	Length      int         `json:"length,omitempty"`
+	Scope       string      `json:"scope,omitempty"`
+	Expression  string      `json:"expression,omitempty"`
+}
+
 // reqPostSeries from /api/v1/series
 type reqPostSeries struct {
 	Series []Metric `json:"series"`
 }
 
-// PostSeries takes as input a slice of metrics and then posts them up to the
+// reqMetrics is the container for receiving metric results.
+type reqMetrics struct {
+	Series []Series `json:"series"`
+}
+
+// PostMetrics takes as input a slice of metrics and then posts them up to the
 // server for posting data.
-func (self *Client) PostMetrics(series []Metric) error {
-	return self.doJsonRequest("POST", "/v1/series",
+func (client *Client) PostMetrics(series []Metric) error {
+	return client.doJsonRequest("POST", "/v1/series",
 		reqPostSeries{Series: series}, nil)
+}
+
+// QueryMetrics takes as input from, to (seconds from Unix Epoch) and query string and then requests
+// timeseries data for that time peried
+func (client *Client) QueryMetrics(from, to int64, query string) ([]Series, error) {
+	var out reqMetrics
+	err := client.doJsonRequest("GET", "/v1/query?from="+strconv.FormatInt(from, 10)+"&to="+strconv.FormatInt(to, 10)+"&query="+query,
+		nil, &out)
+	if err != nil {
+		return nil, err
+	}
+	return out.Series, nil
 }


### PR DESCRIPTION
I've added a query metrics method to implement http://docs.datadoghq.com/api/#metrics-query. I have tested it out on some of my own projects and it successfully fetches back the data. There's also some minor clean up here based on go patterns. This addresses #17 