### PR TITLE
Add CRUD user management functions

### DIFF
--- a/users.go
+++ b/users.go
@@ -8,6 +8,16 @@
 
 package datadog
 
+type User struct {
+	Handle   string `json:"handle"`
+	Email    string `json:"email"`
+	Name     string `json:"name"`
+	Role     string `json:"role"`
+	IsAdmin  bool   `json:"is_admin"`
+	Verified bool   `json:"verified"`
+	Disabled bool   `json:"disabled"`
+}
+
 // reqInviteUsers contains email addresses to send invitations to.
 type reqInviteUsers struct {
 	Emails []string `json:"emails"`
@@ -17,4 +27,45 @@ type reqInviteUsers struct {
 func (self *Client) InviteUsers(emails []string) error {
 	return self.doJsonRequest("POST", "/v1/invite_users",
 		reqInviteUsers{Emails: emails}, nil)
+}
+
+// internal type to retrieve users from the api
+type usersData struct {
+	Users []User `json:"users"`
+}
+
+// GetUsers returns all user, or an error if not found
+func (self *Client) GetUsers() (users []User, err error) {
+	var udata usersData
+	uri := "/v1/user"
+	err = self.doJsonRequest("GET", uri, nil, &udata)
+	users = udata.Users
+	return
+}
+
+// internal type to retrieve single user from the api
+type userData struct {
+	User User `json:"user"`
+}
+
+// GetUser returns the user that match a handle, or an error if not found
+func (self *Client) GetUser(handle string) (user User, err error) {
+	var udata userData
+	uri := "/v1/user/" + handle
+	err = self.doJsonRequest("GET", uri, nil, &udata)
+	user = udata.User
+	return
+}
+
+// UpdateUser updates a user with the content of `user`,
+// and returns an error if the update failed
+func (self *Client) UpdateUser(user User) error {
+	uri := "/v1/user/" + user.Handle
+	return self.doJsonRequest("PUT", uri, user, nil)
+}
+
+// DeleteUser deletes a user and returns an error if deletion failed
+func (self *Client) DeleteUser(handle string) error {
+	uri := "/v1/user/" + handle
+	return self.doJsonRequest("DELETE", uri, nil, nil)
 }


### PR DESCRIPTION
This is a new feature of the Datadog API that is not yet document but available in their Python client. It allows to retrieve, update and delete users. Creation must still happen via invitation.

Sample code:
```go
package main

import (
        "fmt"
        "log"
        "os"

        "github.com/zorkian/go-datadog-api"
)

func main() {
        client := datadog.NewClient(os.Getenv("DATADOG_API_KEY"), os.Getenv("DATADOG_APP_KEY"))

        user, err := client.GetUser("bob@example.net")
        if err != nil {
                log.Fatal(err)
        }
        fmt.Printf("%+v\n", user)

        user.Name = "Bob Kelso"
        user.Disabled = false
        user.IsAdmin = true
        err = client.UpdateUser(user)
        if err != nil {
                log.Fatal(err)
        }

        user, err = client.GetUser(user.Handle)
        if err != nil {
                log.Fatal(err)
        }
        fmt.Printf("%+v\n", user)

        user.Disabled = true
        user.IsAdmin = false
        err = client.UpdateUser(user)
        if err != nil {
                log.Fatal(err)
        }
        user, err = client.GetUser(user.Handle)
        if err != nil {
                log.Fatal(err)
        }
        fmt.Printf("%+v\n", user)

}