### PR TITLE
Return body on error.

### DIFF
--- a/request.go
+++ b/request.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -60,7 +61,11 @@ func (self *Client) doJsonRequest(method, api string,
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return errors.New("API error: " + resp.Status)
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		return errors.New(fmt.Sprintf("API error %s: %s", resp.Status, body))
 	}
 
 	// If they don't care about the body, then we don't care to give them one,

--- a/request.go
+++ b/request.go
@@ -11,7 +11,6 @@ package datadog
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -65,7 +64,7 @@ func (self *Client) doJsonRequest(method, api string,
 		if err != nil {
 			return err
 		}
-		return errors.New(fmt.Sprintf("API error %s: %s", resp.Status, body))
+		return fmt.Errorf("API error %s: %s", resp.Status, body)
 	}
 
 	// If they don't care about the body, then we don't care to give them one,


### PR DESCRIPTION
Which will result in:

```Got error:  API error 400 Bad Request: {"errors":["The value provided for parameter 'query' is invalid"]}``` 

vs the old

```Got error:  API error 400```