### PR TITLE
Fix datadog upstream changes

### DIFF
--- a/monitors.go
+++ b/monitors.go
@@ -41,6 +41,28 @@ type Monitor struct {
 	Options Options `json:"options"`
 }
 
+// Metric Monitor cannot have default zero values for thresholds
+//notifying your team when some defined threshold is exceeded.
+type MetricMonitor struct {
+	Id      int     `json:"id"`
+	Type    string  `json:"type"`
+	Query   string  `json:"query"`
+	Name    string  `json:"name"`
+	Message string  `json:"message"`
+	Options MetricOptions `json:"options"`
+}
+
+type MetricOptions struct {
+	NoDataTimeframe   int               `json:"no_data_timeframe"`
+	NotifyAudit       bool              `json:"notify_audit"`
+	NotifyNoData      bool              `json:"notify_no_data"`
+	Period            int               `json:"period"`
+	RenotifyInterval  int               `json:"renotify_interval"`
+	Silenced          map[string]string `json:"silenced"`
+	TimeoutH          int               `json:"timeout_h"`
+	EscalationMessage string            `json:"escalation_message"`
+}
+
 // reqMonitors receives a slice of all monitors
 type reqMonitors struct {
 	Monitors []Monitor `json:"monitors"`
@@ -57,6 +79,19 @@ func (self *Client) CreateMonitor(monitor *Monitor) (*Monitor, error) {
 	return &out, nil
 }
 
+// CreateMetricmonitor adds a new monitor to the system. This returns a pointer to an
+// monitor so you can pass that to Updatemonitor later if needed.
+func (self *Client) CreateMetricMonitor(monitor *MetricMonitor) (*MetricMonitor, error) {
+	var out MetricMonitor
+	fmt.Println(monitor)
+	err := self.doJsonRequest("POST", "/v1/monitor", monitor, &out)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+//
+
 // Updatemonitor takes an monitor that was previously retrieved through some method
 // and sends it back to the server.
 func (self *Client) UpdateMonitor(monitor *Monitor) error {
@@ -64,9 +99,26 @@ func (self *Client) UpdateMonitor(monitor *Monitor) error {
 		monitor, nil)
 }
 
+// UpdateMetricmonitor takes an monitor that was previously retrieved through some method
+// and sends it back to the server.
+func (self *Client) UpdateMetricMonitor(monitor *MetricMonitor) error {
+	return self.doJsonRequest("PUT", fmt.Sprintf("/v1/monitor/%d", monitor.Id),
+		monitor, nil)
+}
+
 // Getmonitor retrieves an monitor by identifier.
 func (self *Client) GetMonitor(id int) (*Monitor, error) {
 	var out Monitor
+	err := self.doJsonRequest("GET", fmt.Sprintf("/v1/monitor/%d", id), nil, &out)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// Getmonitor retrieves an monitor by identifier.
+func (self *Client) GetMetricMonitor(id int) (*MetricMonitor, error) {
+	var out MetricMonitor
 	err := self.doJsonRequest("GET", fmt.Sprintf("/v1/monitor/%d", id), nil, &out)
 	if err != nil {
 		return nil, err

--- a/monitors.go
+++ b/monitors.go
@@ -13,54 +13,32 @@ import (
 )
 
 type ThresholdCount struct {
-	Ok       int `json:"ok"`
-	Critical int `json:"critical"`
-	Warning  int `json:"warning"`
+	Ok       int `json:"ok,omitempty"`
+	Critical int `json:"critical,omitempty"`
+	Warning  int `json:"warning,omitempty"`
 }
 
 type Options struct {
-	NoDataTimeframe   int               `json:"no_data_timeframe"`
-	NotifyAudit       bool              `json:"notify_audit"`
-	NotifyNoData      bool              `json:"notify_no_data"`
-	Period            int               `json:"period"`
-	RenotifyInterval  int               `json:"renotify_interval"`
-	Silenced          map[string]string `json:"silenced"`
-	TimeoutH          int               `json:"timeout_h"`
-	EscalationMessage string            `json:"escalation_message"`
-	Thresholds        ThresholdCount    `json:"thresholds"`
+	NoDataTimeframe   int               `json:"no_data_timeframe,omitempty"`
+	NotifyAudit       bool              `json:"notify_audit,omitempty"`
+	NotifyNoData      bool              `json:"notify_no_data,omitempty"`
+	Period            int               `json:"period,omitempty"`
+	RenotifyInterval  int               `json:"renotify_interval,omitempty"`
+	Silenced          map[string]string `json:"silenced,omitempty"`
+	TimeoutH          int               `json:"timeout_h,omitempty"`
+	EscalationMessage string            `json:"escalation_message,omitempty"`
+	Thresholds        ThresholdCount    `json:"thresholds,omitempty"`
 }
 
 //Monitors allow you to watch a metric or check that you care about,
 //notifying your team when some defined threshold is exceeded.
 type Monitor struct {
-	Id      int     `json:"id"`
-	Type    string  `json:"type"`
-	Query   string  `json:"query"`
-	Name    string  `json:"name"`
-	Message string  `json:"message"`
-	Options Options `json:"options"`
-}
-
-// Metric Monitor cannot have default zero values for thresholds
-//notifying your team when some defined threshold is exceeded.
-type MetricMonitor struct {
-	Id      int           `json:"id"`
-	Type    string        `json:"type"`
-	Query   string        `json:"query"`
-	Name    string        `json:"name"`
-	Message string        `json:"message"`
-	Options MetricOptions `json:"options"`
-}
-
-type MetricOptions struct {
-	NoDataTimeframe   int               `json:"no_data_timeframe"`
-	NotifyAudit       bool              `json:"notify_audit"`
-	NotifyNoData      bool              `json:"notify_no_data"`
-	Period            int               `json:"period"`
-	RenotifyInterval  int               `json:"renotify_interval"`
-	Silenced          map[string]string `json:"silenced"`
-	TimeoutH          int               `json:"timeout_h"`
-	EscalationMessage string            `json:"escalation_message"`
+	Id      int     `json:"id,omitempty"`
+	Type    string  `json:"type,omitempty"`
+	Query   string  `json:"query,omitempty"`
+	Name    string  `json:"name,omitempty"`
+	Message string  `json:"message,omitempty"`
+	Options Options `json:"option,omitempty"`
 }
 
 // reqMonitors receives a slice of all monitors
@@ -79,19 +57,6 @@ func (self *Client) CreateMonitor(monitor *Monitor) (*Monitor, error) {
 	return &out, nil
 }
 
-// CreateMetricmonitor adds a new monitor to the system. This returns a pointer to an
-// monitor so you can pass that to Updatemonitor later if needed.
-func (self *Client) CreateMetricMonitor(monitor *MetricMonitor) (*MetricMonitor, error) {
-	var out MetricMonitor
-	err := self.doJsonRequest("POST", "/v1/monitor", monitor, &out)
-	if err != nil {
-		return nil, err
-	}
-	return &out, nil
-}
-
-//
-
 // Updatemonitor takes an monitor that was previously retrieved through some method
 // and sends it back to the server.
 func (self *Client) UpdateMonitor(monitor *Monitor) error {
@@ -99,26 +64,9 @@ func (self *Client) UpdateMonitor(monitor *Monitor) error {
 		monitor, nil)
 }
 
-// UpdateMetricmonitor takes an monitor that was previously retrieved through some method
-// and sends it back to the server.
-func (self *Client) UpdateMetricMonitor(monitor *MetricMonitor) error {
-	return self.doJsonRequest("PUT", fmt.Sprintf("/v1/monitor/%d", monitor.Id),
-		monitor, nil)
-}
-
 // Getmonitor retrieves an monitor by identifier.
 func (self *Client) GetMonitor(id int) (*Monitor, error) {
 	var out Monitor
-	err := self.doJsonRequest("GET", fmt.Sprintf("/v1/monitor/%d", id), nil, &out)
-	if err != nil {
-		return nil, err
-	}
-	return &out, nil
-}
-
-// Getmonitor retrieves an monitor by identifier.
-func (self *Client) GetMetricMonitor(id int) (*MetricMonitor, error) {
-	var out MetricMonitor
 	err := self.doJsonRequest("GET", fmt.Sprintf("/v1/monitor/%d", id), nil, &out)
 	if err != nil {
 		return nil, err

--- a/monitors.go
+++ b/monitors.go
@@ -44,11 +44,11 @@ type Monitor struct {
 // Metric Monitor cannot have default zero values for thresholds
 //notifying your team when some defined threshold is exceeded.
 type MetricMonitor struct {
-	Id      int     `json:"id"`
-	Type    string  `json:"type"`
-	Query   string  `json:"query"`
-	Name    string  `json:"name"`
-	Message string  `json:"message"`
+	Id      int           `json:"id"`
+	Type    string        `json:"type"`
+	Query   string        `json:"query"`
+	Name    string        `json:"name"`
+	Message string        `json:"message"`
 	Options MetricOptions `json:"options"`
 }
 
@@ -83,13 +83,13 @@ func (self *Client) CreateMonitor(monitor *Monitor) (*Monitor, error) {
 // monitor so you can pass that to Updatemonitor later if needed.
 func (self *Client) CreateMetricMonitor(monitor *MetricMonitor) (*MetricMonitor, error) {
 	var out MetricMonitor
-	fmt.Println(monitor)
 	err := self.doJsonRequest("POST", "/v1/monitor", monitor, &out)
 	if err != nil {
 		return nil, err
 	}
 	return &out, nil
 }
+
 //
 
 // Updatemonitor takes an monitor that was previously retrieved through some method

--- a/request.go
+++ b/request.go
@@ -16,6 +16,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+    "fmt"
 )
 
 // uriForAPI is to be called with something like "/v1/events" and it will give

--- a/request.go
+++ b/request.go
@@ -16,7 +16,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
-    "fmt"
 )
 
 // uriForAPI is to be called with something like "/v1/events" and it will give


### PR DESCRIPTION
Very inelegant workaround of Datadog API changes. Passing a metric alert with a struct containing an empty Monitor struct (which will have treshold values default to 0) now throws a "400 Bad Request: {"errors":["Critical threshold (0) does not match that used in the query (0)."]}). This broke my provider.

Note sure if you want this in, I just needed a quick fix for terraform-provider-datadog. Using embeds would be nicer, but I could not find a quick way to get that in without breaking backwards compatibility.