### PR TITLE
Fix typo introduced in refactor.

### DIFF
--- a/monitors.go
+++ b/monitors.go
@@ -38,7 +38,7 @@ type Monitor struct {
 	Query   string  `json:"query,omitempty"`
 	Name    string  `json:"name,omitempty"`
 	Message string  `json:"message,omitempty"`
-	Options Options `json:"option,omitempty"`
+	Options Options `json:"options,omitempty"`
 }
 
 // reqMonitors receives a slice of all monitors


### PR DESCRIPTION
This was introduced by my own doings, and took a little while to show up as it is silently dropped by the Datadog API. Sorry about that.