### PR TITLE
Add monitor tests, refactor integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,17 +14,16 @@ updatedeps:
 
 # test runs the unit tests and vets the code
 test:
-	TF_ACC= go test . $(TESTARGS) -timeout=30s -parallel=4
+	go test . $(TESTARGS) -v -timeout=30s -parallel=4
 	@$(MAKE) vet
 
 # testacc runs acceptance tests
 testacc:
-	TF_ACC=1 go test integration_test/dashboards/*.go -v $(TESTARGS) -timeout 90m
-	TF_ACC=1 go test integration_test/screenboards/*.go -v $(TESTARGS) -timeout 90m
+	go test integration/* -v $(TESTARGS) -timeout 90m
 
 # testrace runs the race checker
 testrace:
-	TF_ACC= go test -race $(TEST) $(TESTARGS)
+	go test -race $(TEST) $(TESTARGS)
 
 # vet runs the Go source code static analysis tool `vet` to find
 # any common errors.

--- a/integration/dashboards_test.go
+++ b/integration/dashboards_test.go
@@ -1,40 +1,12 @@
-package integration_test
+package integration
 
 import (
-	"log"
-	"os"
-	"testing"
-
 	"github.com/zorkian/go-datadog-api"
-)
-
-var (
-	apiKey string
-	appKey string
-	client *datadog.Client
+	"testing"
 )
 
 func init() {
-	apiKey = os.Getenv("DATADOG_API_KEY")
-	appKey = os.Getenv("DATADOG_APP_KEY")
-
-	if apiKey == "" || appKey == "" {
-		log.Fatal("Please make sure to set the env variables 'DATADOG_API_KEY' and 'DATADOG_APP_KEY' before running this test")
-	}
-
-	client = datadog.NewClient(apiKey, appKey)
-}
-
-func TestMain(m *testing.M) {
-	num := countDashboards()
-
-	result := m.Run()
-
-	if num != countDashboards() {
-		log.Fatal("Tests didn't clean-up all created dashboards. Manual clean-up required.")
-	}
-
-	os.Exit(result)
+	client = initTest()
 }
 
 func TestCreateAndDeleteDashboard(t *testing.T) {
@@ -44,6 +16,9 @@ func TestCreateAndDeleteDashboard(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Creating a dashboard failed when it shouldn't. (%s)", err)
 	}
+
+	defer cleanUpDashboard(t, actual.Id)
+
 	assertDashboardEquals(t, actual, expected)
 
 	// now try to fetch it freshly and compare it again
@@ -52,7 +27,7 @@ func TestCreateAndDeleteDashboard(t *testing.T) {
 		t.Fatalf("Retrieving a dashboard failed when it shouldn't. (%s)", err)
 	}
 	assertDashboardEquals(t, actual, expected)
-	cleanUpDashboard(t, actual.Id)
+
 }
 
 func TestUpdateDashboard(t *testing.T) {
@@ -62,6 +37,7 @@ func TestUpdateDashboard(t *testing.T) {
 		t.Fatalf("Creating a dashboard failed when it shouldn't. (%s)", err)
 	}
 
+	defer cleanUpDashboard(t, board.Id)
 	board.Title = "___New-Test-Board___"
 
 	if err := client.UpdateDashboard(board); err != nil {
@@ -74,7 +50,6 @@ func TestUpdateDashboard(t *testing.T) {
 	}
 
 	assertDashboardEquals(t, actual, board)
-	cleanUpDashboard(t, actual.Id)
 }
 
 func TestGetDashboards(t *testing.T) {
@@ -82,9 +57,10 @@ func TestGetDashboards(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Retrieving dashboards failed when it shouldn't: %s", err)
 	}
-	num := len(boards)
 
+	num := len(boards)
 	board := createTestDashboard(t)
+	defer cleanUpDashboard(t, board.Id)
 
 	boards, err = client.GetDashboards()
 	if err != nil {
@@ -94,8 +70,6 @@ func TestGetDashboards(t *testing.T) {
 	if num+1 != len(boards) {
 		t.Fatalf("Number of dashboards didn't match expected: %d != %d", len(boards), num+1)
 	}
-
-	cleanUpDashboard(t, board.Id)
 }
 
 func getTestDashboard() *datadog.Dashboard {
@@ -119,26 +93,17 @@ func createTestDashboard(t *testing.T) *datadog.Dashboard {
 
 func cleanUpDashboard(t *testing.T, id int) {
 	if err := client.DeleteDashboard(id); err != nil {
-		t.Fatalf("Deleting a dashboard failed when it shouldn't. (%s)", err)
+		t.Fatalf("Deleting a dashboard failed when it shouldn't. Manual cleanup needed. (%s)", err)
 	}
 
 	deletedBoard, err := client.GetDashboard(id)
 	if deletedBoard != nil {
-		t.Fatal("Dashboard hasn't been deleted when it should have been.")
+		t.Fatal("Dashboard hasn't been deleted when it should have been. Manual cleanup needed.")
 	}
 
 	if err == nil {
-		t.Fatal("Fetching deleted dashboard didn't lead to an error.")
+		t.Fatal("Fetching deleted dashboard didn't lead to an error. Manual cleanup needed.")
 	}
-}
-
-func countDashboards() int {
-	boards, err := client.GetDashboards()
-	if err != nil {
-		log.Fatalf("Error retrieving dashboards: %s", err)
-	}
-
-	return len(boards)
 }
 
 type TestGraphDefintionRequests struct {

--- a/integration/monitors_test.go
+++ b/integration/monitors_test.go
@@ -1,0 +1,152 @@
+package integration
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/zorkian/go-datadog-api"
+	"testing"
+)
+
+func init() {
+	client = initTest()
+}
+
+func TestCreateAndDeleteMonitor(t *testing.T) {
+	expected := getTestMonitor()
+	// create the monitor and compare it
+	actual := createTestMonitor(t)
+	defer cleanUpMonitor(t, actual.Id)
+
+	// Set ID of our original struct to zero we we can easily compare the results
+	expected.Id = actual.Id
+	assert.Equal(t, expected, actual)
+
+	actual, err := client.GetMonitor(actual.Id)
+	if err != nil {
+		t.Fatalf("Retrieving a monitor failed when it shouldn't: (%s)", err)
+	}
+	assert.Equal(t, expected, actual)
+}
+
+func TestUpdateMonitor(t *testing.T) {
+
+	monitor := createTestMonitor(t)
+	defer cleanUpMonitor(t, monitor.Id)
+
+	monitor.Name = "___New-Test-Monitor___"
+	if err := client.UpdateMonitor(monitor); err != nil {
+		t.Fatalf("Updating a monitor failed when it shouldn't: %s", err)
+	}
+
+	actual, err := client.GetMonitor(monitor.Id)
+	if err != nil {
+		t.Fatalf("Retrieving a monitor failed when it shouldn't: %s", err)
+	}
+
+	assert.Equal(t, monitor, actual)
+
+}
+
+func TestGetMonitor(t *testing.T) {
+	monitors, err := client.GetMonitors()
+	if err != nil {
+		t.Fatalf("Retrieving monitors failed when it shouldn't: %s", err)
+	}
+	num := len(monitors)
+
+	monitor := createTestMonitor(t)
+	defer cleanUpMonitor(t, monitor.Id)
+
+	monitors, err = client.GetMonitors()
+	if err != nil {
+		t.Fatalf("Retrieving monitors failed when it shouldn't: %s", err)
+	}
+
+	if num+1 != len(monitors) {
+		t.Fatalf("Number of monitors didn't match expected: %d != %d", len(monitors), num+1)
+	}
+}
+
+func TestMuteUnmuteMonitor(t *testing.T) {
+	monitor := createTestMonitor(t)
+	defer cleanUpMonitor(t, monitor.Id)
+
+	// Mute
+	err := client.MuteMonitor(monitor.Id)
+	if err != nil {
+		t.Fatalf("Failed to mute monitor")
+
+	}
+
+	monitor, err = client.GetMonitor(monitor.Id)
+	if err != nil {
+		t.Fatalf("Retrieving monitors failed when it shouldn't: %s", err)
+	}
+
+	// Mute without options will result in monitor.Options.Silenced
+	// to have a key of "*" with value 0
+	assert.Equal(t, 0, monitor.Options.Silenced["*"])
+
+	// Unmute
+	err = client.UnmuteMonitor(monitor.Id)
+	if err != nil {
+		t.Fatalf("Failed to unmute monitor")
+	}
+
+	// Update remote state
+	monitor, err = client.GetMonitor(monitor.Id)
+	if err != nil {
+		t.Fatalf("Retrieving monitors failed when it shouldn't: %s", err)
+	}
+
+	// Assert this map is empty
+	assert.Equal(t, 0, len(monitor.Options.Silenced))
+}
+
+/*
+	Testing of global mute and unmuting has not been added for following reasons:
+	* Disabling and enabling of global monitoring does an @all mention which is noisy
+	* It exposes risk to users that run integration tests in their main account
+	* There is no endpoint to verify success
+*/
+
+func getTestMonitor() *datadog.Monitor {
+
+	o := datadog.Options{
+		NotifyNoData:    true,
+		NoDataTimeframe: 60,
+		Silenced:        map[string]int{},
+	}
+
+	return &datadog.Monitor{
+		Message: "Test message",
+		Query:   "avg(last_15m):avg:system.disk.in_use{*} by {host,device} > 0.8",
+		Name:    "Test monitor",
+		Options: o,
+		Type:    "metric alert",
+	}
+}
+
+func createTestMonitor(t *testing.T) *datadog.Monitor {
+	monitor := getTestMonitor()
+	monitor, err := client.CreateMonitor(monitor)
+	if err != nil {
+		t.Fatalf("Creating a monitor failed when it shouldn't: %s", err)
+	}
+
+	return monitor
+}
+
+func cleanUpMonitor(t *testing.T, id int) {
+	if err := client.DeleteMonitor(id); err != nil {
+		t.Fatalf("Deleting a monitor failed when it shouldn't. Manual cleanup needed. (%s)", err)
+	}
+
+	deletedMonitor, err := client.GetMonitor(id)
+	if deletedMonitor != nil {
+		t.Fatal("Monitor hasn't been deleted when it should have been. Manual cleanup needed.")
+	}
+
+	if err == nil {
+		t.Fatal("Fetching deleted monitor didn't lead to an error.")
+	}
+}

--- a/integration/screen_widgets_test.go
+++ b/integration/screen_widgets_test.go
@@ -1,4 +1,4 @@
-package integration_test
+package integration
 
 import (
 	"testing"
@@ -8,6 +8,7 @@ import (
 
 func TestAlertValueWidget(t *testing.T) {
 	board := createTestScreenboard(t)
+	defer cleanUpScreenboard(t, board.Id)
 
 	expected := datadog.Widget{}.AlertValueWidget
 
@@ -55,12 +56,11 @@ func TestAlertValueWidget(t *testing.T) {
 	assertEquals(t, "type", actualWidget.Type, expected.Type)
 	assertEquals(t, "unit", actualWidget.Unit, expected.Unit)
 	assertEquals(t, "add_timeframe", actualWidget.AddTimeframe, expected.AddTimeframe)
-
-	cleanUpScreenboard(t, board.Id)
 }
 
 func TestChangeWidget(t *testing.T) {
 	board := createTestScreenboard(t)
+	defer cleanUpScreenboard(t, board.Id)
 
 	expected := datadog.Widget{}.ChangeWidget
 
@@ -100,12 +100,11 @@ func TestChangeWidget(t *testing.T) {
 	assertEquals(t, "title", actualWidget.Title, expected.Title)
 	assertEquals(t, "aggregator", actualWidget.Aggregator, expected.Aggregator)
 	assertTileDefEquals(t, actualWidget.TileDef, expected.TileDef)
-
-	cleanUpScreenboard(t, board.Id)
 }
 
 func TestGraphWidget(t *testing.T) {
 	board := createTestScreenboard(t)
+	defer cleanUpScreenboard(t, board.Id)
 
 	expected := datadog.Widget{}.GraphWidget
 
@@ -151,12 +150,11 @@ func TestGraphWidget(t *testing.T) {
 	assertEquals(t, "legend", actualWidget.Legend, expected.Legend)
 	assertEquals(t, "legend_size", actualWidget.LegendSize, expected.LegendSize)
 	assertTileDefEquals(t, actualWidget.TileDef, expected.TileDef)
-
-	cleanUpScreenboard(t, board.Id)
 }
 
 func TestEventTimelineWidget(t *testing.T) {
 	board := createTestScreenboard(t)
+	defer cleanUpScreenboard(t, board.Id)
 
 	expected := datadog.Widget{}.EventTimelineWidget
 
@@ -198,12 +196,11 @@ func TestEventTimelineWidget(t *testing.T) {
 	assertEquals(t, "type", actualWidget.Type, expected.Type)
 	assertEquals(t, "query", actualWidget.Query, expected.Query)
 	assertEquals(t, "timeframe", actualWidget.Timeframe, expected.Timeframe)
-
-	cleanUpScreenboard(t, board.Id)
 }
 
 func TestAlertGraphWidget(t *testing.T) {
 	board := createTestScreenboard(t)
+	defer cleanUpScreenboard(t, board.Id)
 
 	expected := datadog.Widget{}.AlertGraphWidget
 
@@ -249,12 +246,11 @@ func TestAlertGraphWidget(t *testing.T) {
 	assertEquals(t, "timeframe", actualWidget.Timeframe, expected.Timeframe)
 	assertEquals(t, "add_timeframe", actualWidget.AddTimeframe, expected.AddTimeframe)
 	assertEquals(t, "alert_id", actualWidget.AlertId, expected.AlertId)
-
-	cleanUpScreenboard(t, board.Id)
 }
 
 func TestHostMapWidget(t *testing.T) {
 	board := createTestScreenboard(t)
+	defer cleanUpScreenboard(t, board.Id)
 
 	expected := datadog.Widget{}.HostMapWidget
 
@@ -303,12 +299,11 @@ func TestHostMapWidget(t *testing.T) {
 	assertEquals(t, "legend", actualWidget.Legend, expected.Legend)
 	assertEquals(t, "legend_size", actualWidget.LegendSize, expected.LegendSize)
 	assertTileDefEquals(t, actualWidget.TileDef, expected.TileDef)
-
-	cleanUpScreenboard(t, board.Id)
 }
 
 func TestCheckStatusWidget(t *testing.T) {
 	board := createTestScreenboard(t)
+	defer cleanUpScreenboard(t, board.Id)
 
 	expected := datadog.Widget{}.CheckStatusWidget
 
@@ -357,12 +352,11 @@ func TestCheckStatusWidget(t *testing.T) {
 	assertEquals(t, "check", actualWidget.Check, expected.Check)
 	assertEquals(t, "group", actualWidget.Group, expected.Group)
 	assertEquals(t, "grouping", actualWidget.Grouping, expected.Grouping)
-
-	cleanUpScreenboard(t, board.Id)
 }
 
 func TestIFrameWidget(t *testing.T) {
 	board := createTestScreenboard(t)
+	defer cleanUpScreenboard(t, board.Id)
 
 	expected := datadog.Widget{}.IFrameWidget
 
@@ -402,12 +396,11 @@ func TestIFrameWidget(t *testing.T) {
 	assertEquals(t, "title", actualWidget.Title, expected.Title)
 	assertEquals(t, "url", actualWidget.Url, expected.Url)
 	assertEquals(t, "type", actualWidget.Type, expected.Type)
-
-	cleanUpScreenboard(t, board.Id)
 }
 
 func TestNoteWidget(t *testing.T) {
 	board := createTestScreenboard(t)
+	defer cleanUpScreenboard(t, board.Id)
 
 	expected := datadog.Widget{}.NoteWidget
 
@@ -461,12 +454,11 @@ func TestNoteWidget(t *testing.T) {
 	assertEquals(t, "html", actualWidget.Html, expected.Html)
 	assertEquals(t, "note", actualWidget.Note, expected.Note)
 	assertEquals(t, "auto_refresh", actualWidget.AutoRefresh, expected.AutoRefresh)
-
-	cleanUpScreenboard(t, board.Id)
 }
 
 func TestToplistWidget(t *testing.T) {
 	board := createTestScreenboard(t)
+	defer cleanUpScreenboard(t, board.Id)
 
 	expected := datadog.Widget{}.ToplistWidget
 	expected.X = 1
@@ -507,12 +499,11 @@ func TestToplistWidget(t *testing.T) {
 	assertEquals(t, "title_align", actualWidget.TitleAlign, expected.TitleAlign)
 	assertEquals(t, "legend", actualWidget.Legend, expected.Legend)
 	assertEquals(t, "legend_size", actualWidget.LegendSize, expected.LegendSize)
-
-	cleanUpScreenboard(t, board.Id)
 }
 
 func TestEventSteamWidget(t *testing.T) {
 	board := createTestScreenboard(t)
+	defer cleanUpScreenboard(t, board.Id)
 
 	expected := datadog.Widget{}.EventStreamWidget
 	expected.EventSize = "1"
@@ -556,12 +547,11 @@ func TestEventSteamWidget(t *testing.T) {
 	assertEquals(t, "title_size", actualWidget.TitleSize, expected.TitleSize)
 	assertEquals(t, "title_text", actualWidget.TitleText, expected.TitleText)
 	assertEquals(t, "type", actualWidget.Type, expected.Type)
-
-	cleanUpScreenboard(t, board.Id)
 }
 
 func TestImageWidget(t *testing.T) {
 	board := createTestScreenboard(t)
+	defer cleanUpScreenboard(t, board.Id)
 
 	expected := datadog.Widget{}.ImageWidget
 
@@ -604,12 +594,11 @@ func TestImageWidget(t *testing.T) {
 	assertEquals(t, "type", actualWidget.Type, expected.Type)
 	assertEquals(t, "url", actualWidget.Url, expected.Url)
 	assertEquals(t, "sizing", actualWidget.Sizing, expected.Sizing)
-
-	cleanUpScreenboard(t, board.Id)
 }
 
 func TestFreeTextWidget(t *testing.T) {
 	board := createTestScreenboard(t)
+	defer cleanUpScreenboard(t, board.Id)
 
 	expected := datadog.Widget{}.FreeTextWidget
 
@@ -644,12 +633,11 @@ func TestFreeTextWidget(t *testing.T) {
 	assertEquals(t, "text", actualWidget.Text, expected.Text)
 	assertEquals(t, "text-align", actualWidget.TextAlign, expected.TextAlign)
 	assertEquals(t, "type", actualWidget.Type, expected.Type)
-
-	cleanUpScreenboard(t, board.Id)
 }
 
 func TestTimeseriesWidget(t *testing.T) {
 	board := createTestScreenboard(t)
+	defer cleanUpScreenboard(t, board.Id)
 
 	expected := datadog.Widget{}.TimeseriesWidget
 	expected.X = 1
@@ -689,12 +677,11 @@ func TestTimeseriesWidget(t *testing.T) {
 	assertEquals(t, "timeframe", actualWidget.Timeframe, expected.Timeframe)
 	assertEquals(t, "legend", actualWidget.Legend, expected.Legend)
 	assertTileDefEquals(t, actualWidget.TileDef, expected.TileDef)
-
-	cleanUpScreenboard(t, board.Id)
 }
 
 func TestQueryValueWidget(t *testing.T) {
 	board := createTestScreenboard(t)
+	defer cleanUpScreenboard(t, board.Id)
 
 	expected := datadog.Widget{}.QueryValueWidget
 	expected.X = 1
@@ -755,8 +742,6 @@ func TestQueryValueWidget(t *testing.T) {
 	assertEquals(t, "is_valid_query", actualWidget.IsValidQuery, expected.IsValidQuery)
 	assertEquals(t, "res_calc_func", actualWidget.ResultCalcFunc, expected.ResultCalcFunc)
 	assertEquals(t, "aggr", actualWidget.Aggregator, expected.Aggregator)
-
-	cleanUpScreenboard(t, board.Id)
 }
 
 func assertTileDefEquals(t *testing.T, actual datadog.TileDef, expected datadog.TileDef) {

--- a/integration/test_helpers.go
+++ b/integration/test_helpers.go
@@ -1,0 +1,24 @@
+package integration
+
+import (
+	"github.com/zorkian/go-datadog-api"
+	"log"
+	"os"
+)
+
+var (
+	apiKey string
+	appKey string
+	client *datadog.Client
+)
+
+func initTest() *datadog.Client {
+	apiKey = os.Getenv("DATADOG_API_KEY")
+	appKey = os.Getenv("DATADOG_APP_KEY")
+
+	if apiKey == "" || appKey == "" {
+		log.Fatal("Please make sure to set the env variables 'DATADOG_API_KEY' and 'DATADOG_APP_KEY' before running this test")
+	}
+
+	return datadog.NewClient(apiKey, appKey)
+}


### PR DESCRIPTION
* Add tests for some but not all monitor functions
* Add helper file with init helper function
* Reverse assert.Equal calls to the error it expects
* Update comments

````
> make testacc
go test integration/* -v  -timeout 90m
=== RUN   TestCreateAndDeleteDashboard
--- PASS: TestCreateAndDeleteDashboard (4.23s)
=== RUN   TestUpdateDashboard
--- PASS: TestUpdateDashboard (2.64s)
=== RUN   TestGetDashboards
--- PASS: TestGetDashboards (1.88s)
=== RUN   TestCreateAndDeleteMonitor
--- PASS: TestCreateAndDeleteMonitor (2.21s)
=== RUN   TestUpdateMonitor
--- PASS: TestUpdateMonitor (3.62s)
=== RUN   TestGetMonitor
--- PASS: TestGetMonitor (2.65s)
=== RUN   TestMuteUnmuteMonitor
--- PASS: TestMuteUnmuteMonitor (4.69s)
=== RUN   TestAlertValueWidget
--- PASS: TestAlertValueWidget (3.43s)
=== RUN   TestChangeWidget
--- PASS: TestChangeWidget (3.40s)
=== RUN   TestGraphWidget
--- PASS: TestGraphWidget (3.16s)
=== RUN   TestEventTimelineWidget
--- PASS: TestEventTimelineWidget (3.38s)
=== RUN   TestAlertGraphWidget
--- PASS: TestAlertGraphWidget (3.39s)
=== RUN   TestHostMapWidget
--- PASS: TestHostMapWidget (3.24s)
=== RUN   TestCheckStatusWidget
--- PASS: TestCheckStatusWidget (3.21s)
=== RUN   TestIFrameWidget
--- PASS: TestIFrameWidget (3.28s)
=== RUN   TestNoteWidget
--- PASS: TestNoteWidget (3.25s)
=== RUN   TestToplistWidget
--- PASS: TestToplistWidget (3.36s)
=== RUN   TestEventSteamWidget
--- PASS: TestEventSteamWidget (3.36s)
=== RUN   TestImageWidget
--- PASS: TestImageWidget (4.96s)
=== RUN   TestFreeTextWidget
--- PASS: TestFreeTextWidget (3.46s)
=== RUN   TestTimeseriesWidget
--- PASS: TestTimeseriesWidget (4.41s)
=== RUN   TestQueryValueWidget
--- PASS: TestQueryValueWidget (3.41s)
=== RUN   TestCreateAndDeleteScreenboard
--- PASS: TestCreateAndDeleteScreenboard (2.16s)
=== RUN   TestShareAndRevokeScreenboard
--- PASS: TestShareAndRevokeScreenboard (3.37s)
=== RUN   TestUpdateScreenboard
--- PASS: TestUpdateScreenboard (3.28s)
=== RUN   TestGetScreenboards
--- PASS: TestGetScreenboards (2.54s)
PASS
ok  	command-line-arguments	86.022s
```