### PR TITLE
Allow accessing a time series aggregator

### DIFF
--- a/series.go
+++ b/series.go
@@ -32,6 +32,7 @@ type Series struct {
 	Start       float64     `json:"start,omitempty"`
 	End         float64     `json:"end,omitempty"`
 	Interval    int         `json:"interval,omitempty"`
+	Aggr        string      `json:"aggr,omitempty"`
 	Length      int         `json:"length,omitempty"`
 	Scope       string      `json:"scope,omitempty"`
 	Expression  string      `json:"expression,omitempty"`


### PR DESCRIPTION
This attribute is returned when querying for metrics as [described in the docs](http://docs.datadoghq.com/api/#metrics-query). Its value is something like `"min"` or `"max"`.