### PR TITLE
Add support for downtime api

### DIFF
--- a/downtimes.go
+++ b/downtimes.go
@@ -1,0 +1,83 @@
+/*
+ * Datadog API for Go
+ *
+ * Please see the included LICENSE file for licensing information.
+ *
+ * Copyright 2013 by authors and contributors.
+ */
+
+package datadog
+
+import (
+	"fmt"
+)
+
+type Recurrence struct {
+	Period           int      `json:"period,omitempty"`
+	Type             string   `json:"type,omitempty"`
+	UntilDate        int      `json:"until_date,omitempty"`
+	UntilOccurrences int      `json:"until_occurrences,omitempty"`
+	WeekDays         []string `json:"week_days,omitempty"`
+}
+
+type Downtime struct {
+	Active     bool       `json:"active,omitempty"`
+	Canceled   int        `json:"canceled,omitempty"`
+	Disabled   bool       `json:"disabled,omitempty"`
+	End        int        `json:"end,omitempty"`
+	Id         int        `json:"id,omitempty"`
+	Message    string     `json:"message,omitempty"`
+	Recurrence Recurrence `json:"recurrence,omitempty"`
+	Scope      []string   `json:"scope,omitempty"`
+	Start      int        `json:"start,omitempty"`
+}
+
+// reqDowntimes retrieves a slice of all Downtimes.
+type reqDowntimes struct {
+	Downtimes []Downtime `json:"downtimes,omitempty"`
+}
+
+// CreateDowntime adds a new downtme to the system. This returns a pointer
+// to a Downtime so you can pass that to UpdateDowntime or CancelDowntime
+// later if needed.
+func (self *Client) CreateDowntime(downtime *Downtime) (*Downtime, error) {
+	var out Downtime
+	err := self.doJsonRequest("POST", "/v1/downtime", downtime, &out)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// UpdateDowntime takes a downtime that was previously retrieved through some method
+// and sends it back to the server.
+func (self *Client) UpdateDowntime(downtime *Downtime) error {
+	return self.doJsonRequest("PUT", fmt.Sprintf("/v1/downtime/%d", downtime.Id),
+		downtime, nil)
+}
+
+// Getdowntime retrieves an downtime by identifier.
+func (self *Client) GetDowntime(id int) (*Downtime, error) {
+	var out Downtime
+	err := self.doJsonRequest("GET", fmt.Sprintf("/v1/downtime/%d", id), nil, &out)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// DeleteDowntime removes an downtime from the system.
+func (self *Client) DeleteDowntime(id int) error {
+	return self.doJsonRequest("DELETE", fmt.Sprintf("/v1/downtime/%d", id),
+		nil, nil)
+}
+
+// GetDowntimes returns a slice of all downtimes.
+func (self *Client) GetDowntimes() ([]Downtime, error) {
+	var out reqDowntimes
+	err := self.doJsonRequest("GET", "/v1/downtime", nil, &out.Downtimes)
+	if err != nil {
+		return nil, err
+	}
+	return out.Downtimes, nil
+}

--- a/integration/downtime_test.go
+++ b/integration/downtime_test.go
@@ -1,0 +1,110 @@
+package integration
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/zorkian/go-datadog-api"
+	"testing"
+)
+
+func init() {
+	client = initTest()
+}
+
+func TestCreateAndDeleteDowntime(t *testing.T) {
+	expected := getTestDowntime()
+	// create the downtime and compare it
+	actual := createTestDowntime(t)
+	defer cleanUpDowntime(t, actual.Id)
+
+	// Set ID of our original struct to zero we we can easily compare the results
+	expected.Id = actual.Id
+	assert.Equal(t, expected, actual)
+
+	actual, err := client.GetDowntime(actual.Id)
+	if err != nil {
+		t.Fatalf("Retrieving a downtime failed when it shouldn't: (%s)", err)
+	}
+	assert.Equal(t, expected, actual)
+}
+
+func TestUpdateDowntime(t *testing.T) {
+
+	downtime := createTestDowntime(t)
+
+	downtime.Scope = []string{"env:downtime_test", "env:downtime_test2"}
+	defer cleanUpDowntime(t, downtime.Id)
+
+	if err := client.UpdateDowntime(downtime); err != nil {
+		t.Fatalf("Updating a downtime failed when it shouldn't: %s", err)
+	}
+
+	actual, err := client.GetDowntime(downtime.Id)
+	if err != nil {
+		t.Fatalf("Retrieving a downtime failed when it shouldn't: %s", err)
+	}
+
+	assert.Equal(t, downtime, actual)
+
+}
+
+func TestGetDowntime(t *testing.T) {
+	downtimes, err := client.GetDowntimes()
+	if err != nil {
+		t.Fatalf("Retrieving downtimes failed when it shouldn't: %s", err)
+	}
+	num := len(downtimes)
+
+	downtime := createTestDowntime(t)
+	defer cleanUpDowntime(t, downtime.Id)
+
+	downtimes, err = client.GetDowntimes()
+	if err != nil {
+		t.Fatalf("Retrieving downtimes failed when it shouldn't: %s", err)
+	}
+
+	if num+1 != len(downtimes) {
+		t.Fatalf("Number of downtimes didn't match expected: %d != %d", len(downtimes), num+1)
+	}
+}
+
+func getTestDowntime() *datadog.Downtime {
+
+	r := datadog.Recurrence{
+		Type:     "weeks",
+		Period:   1,
+		WeekDays: []string{"Mon", "Tue", "Wed", "Thu", "Fri"},
+	}
+
+	return &datadog.Downtime{
+		Message:    "Test downtime message",
+		Scope:      []string{"env:downtime_test"},
+		Start:      1577836800,
+		End:        1577840400,
+		Recurrence: r,
+	}
+}
+
+func createTestDowntime(t *testing.T) *datadog.Downtime {
+	downtime := getTestDowntime()
+	downtime, err := client.CreateDowntime(downtime)
+	if err != nil {
+		t.Fatalf("Creating a downtime failed when it shouldn't: %s", err)
+	}
+
+	return downtime
+}
+
+func cleanUpDowntime(t *testing.T, id int) {
+	if err := client.DeleteDowntime(id); err != nil {
+		t.Fatalf("Deleting a downtime failed when it shouldn't. Manual cleanup needed. (%s)", err)
+	}
+
+	deletedDowntime, err := client.GetDowntime(id)
+	if deletedDowntime != nil && deletedDowntime.Canceled == 0 {
+		t.Fatal("Downtime hasn't been deleted when it should have been. Manual cleanup needed.")
+	}
+
+	if err == nil && deletedDowntime.Canceled == 0 {
+		t.Fatal("Fetching deleted downtime didn't lead to an error and downtime Canceled not set.")
+	}
+}


### PR DESCRIPTION
This adds support and tests for the /v1/downtime api as outlined at http://docs.datadoghq.com/api/.