### PR TITLE
Add possibility to take graph snapshots

### DIFF
--- a/snapshot.go
+++ b/snapshot.go
@@ -1,0 +1,33 @@
+/*
+ * Datadog API for Go
+ *
+ * Please see the included LICENSE file for licensing information.
+ *
+ * Copyright 2016 by authors and contributors.
+ */
+
+package datadog
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// Snapshot creates an image from a graph and returns the URL of the image.
+func (self *Client) Snapshot(query string, start, end time.Time, eventQuery string) (string, error) {
+	v := url.Values{}
+	v.Add("start", fmt.Sprintf("%d", start.Unix()))
+	v.Add("end", fmt.Sprintf("%d", end.Unix()))
+	v.Add("metric_query", query)
+	v.Add("event_query", eventQuery)
+
+	out := struct {
+		SnapshotURL string `json:"snapshot_url"`
+	}{}
+	err := self.doJsonRequest("GET", "/v1/graph/snapshot?"+v.Encode(), nil, &out)
+	if err != nil {
+		return "", err
+	}
+	return out.SnapshotURL, nil
+}


### PR DESCRIPTION
This feature is documented here: http://docs.datadoghq.com/api/#graph-snapshot
Datadog takes screenshots of graphs, uploads these files to S3 and returns a public URL.