### PR TITLE
Allows omitempty to work on Downtimes w/o Recurrence

### DIFF
--- a/downtimes.go
+++ b/downtimes.go
@@ -21,15 +21,15 @@ type Recurrence struct {
 }
 
 type Downtime struct {
-	Active     bool       `json:"active,omitempty"`
-	Canceled   int        `json:"canceled,omitempty"`
-	Disabled   bool       `json:"disabled,omitempty"`
-	End        int        `json:"end,omitempty"`
-	Id         int        `json:"id,omitempty"`
-	Message    string     `json:"message,omitempty"`
-	Recurrence Recurrence `json:"recurrence,omitempty"`
-	Scope      []string   `json:"scope,omitempty"`
-	Start      int        `json:"start,omitempty"`
+	Active     bool        `json:"active,omitempty"`
+	Canceled   int         `json:"canceled,omitempty"`
+	Disabled   bool        `json:"disabled,omitempty"`
+	End        int         `json:"end,omitempty"`
+	Id         int         `json:"id,omitempty"`
+	Message    string      `json:"message,omitempty"`
+	Recurrence *Recurrence `json:"recurrence,omitempty"`
+	Scope      []string    `json:"scope,omitempty"`
+	Start      int         `json:"start,omitempty"`
 }
 
 // reqDowntimes retrieves a slice of all Downtimes.

--- a/integration/downtime_test.go
+++ b/integration/downtime_test.go
@@ -69,7 +69,7 @@ func TestGetDowntime(t *testing.T) {
 
 func getTestDowntime() *datadog.Downtime {
 
-	r := datadog.Recurrence{
+	r := &datadog.Recurrence{
 		Type:     "weeks",
 		Period:   1,
 		WeekDays: []string{"Mon", "Tue", "Wed", "Thu", "Fri"},


### PR DESCRIPTION
When not using a pointer, Recurrence was always posting data as omitempty cannot handle a non-pointer struct.  This way, if someone does not want to specify the 'optional' Recurrence, they do not have to.