### PR TITLE
Add support for checks API

### DIFF
--- a/checks.go
+++ b/checks.go
@@ -1,0 +1,25 @@
+package datadog
+
+type Check struct {
+	Check     string   `json:"check"`
+	HostName  string   `json:"host_name"`
+	Status    status   `json:"status"`
+	Timestamp string   `json:"timestamp,omitempty"`
+	Message   string   `json:"message,omitempty"`
+	Tags      []string `json:"tags,omitempty"`
+}
+
+type status int
+
+const (
+	OK status = iota
+	WARNING
+	CRITICAL
+	UNKNOWN
+)
+
+// PostCheck posts the result of a check run to the server
+func (client *Client) PostCheck(check Check) error {
+	return client.doJsonRequest("POST", "/v1/check_run",
+		check, nil)
+}

--- a/checks_test.go
+++ b/checks_test.go
@@ -1,0 +1,22 @@
+package datadog_test
+
+import (
+	"testing"
+
+	"github.com/zorkian/go-datadog-api"
+)
+
+func TestCheckStatus(T *testing.T) {
+	if datadog.OK != 0 {
+		T.Error("status OK must be 0 to satisfy Datadog's API")
+	}
+	if datadog.WARNING != 1 {
+		T.Error("status WARNING must be 1 to satisfy Datadog's API")
+	}
+	if datadog.CRITICAL != 2 {
+		T.Error("status CRITICAL must be 2 to satisfy Datadog's API")
+	}
+	if datadog.UNKNOWN != 3 {
+		T.Error("status UNKNOWN must be 3 to satisfy Datadog's API")
+	}
+}


### PR DESCRIPTION
http://docs.datadoghq.com/api/#service_checks

Example usage:
```go
client := datadog.NewClient(apiKey, appKey)
client.PostCheck(datadog.Check{
    Check:    "check name",
    Status:   datadog.CRITICAL,
    Message:  "check message",
    Tags:     []string{"tag1:val1", "tag2:val2"},
    HostName: "hostname",
})
```