### PR TITLE
Support CreateUser API

### DIFF
--- a/integration/users_test.go
+++ b/integration/users_test.go
@@ -1,0 +1,42 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	client = initTest()
+}
+
+func TestCreateAndDeleteUser(t *testing.T) {
+	handle := "test@example.com"
+	name := "tester"
+
+	user, err := client.CreateUser(handle, name)
+	if err != nil {
+		t.Fatalf("Failed to create user: %s", err)
+	}
+	if user == nil {
+		t.Fatalf("CreateUser did not return an user.")
+	}
+
+	defer func() {
+		err := client.DeleteUser(handle)
+		if err != nil {
+			t.Fatalf("Failed to delete user: %s", err)
+		}
+	}()
+
+	assert.Equal(t, user.Handle, handle)
+	assert.Equal(t, user.Name, name)
+
+	newUser, err := client.GetUser(handle)
+	if err != nil {
+		t.Fatalf("Failed to get user: %s", err)
+	}
+
+	assert.Equal(t, newUser.Handle, handle)
+	assert.Equal(t, newUser.Name, name)
+}

--- a/users.go
+++ b/users.go
@@ -29,6 +29,25 @@ func (self *Client) InviteUsers(emails []string) error {
 		reqInviteUsers{Emails: emails}, nil)
 }
 
+// CreateUser creates an user account for an email address
+func (self *Client) CreateUser(handle, name string) (*User, error) {
+	in := struct {
+		Handle string `json:"handle"`
+		Name   string `json:"name"`
+	}{
+		Handle: handle,
+		Name:   name,
+	}
+
+	out := struct {
+		*User `json:"user"`
+	}{}
+	if err := self.doJsonRequest("POST", "/v1/user", in, &out); err != nil {
+		return nil, err
+	}
+	return out.User, nil
+}
+
 // internal type to retrieve users from the api
 type usersData struct {
 	Users []User `json:"users"`


### PR DESCRIPTION
Datadog introduced an API to create users that differs from the (undocumented) one we currently support (https://github.com/zorkian/go-datadog-api/blob/master/users.go#L28). This PR adds a method `CreateUser` that allows users to add user accounts based on an email address and a name.

fixes #37

## Todo: 

- [x] Write integration tests
- [ ] Find a way to automatically clean up test users