### PR TITLE
[trace:loom] optimize

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,3 +28,9 @@ func NewClient(apiKey, appKey string) *Client {
 		HttpClient: http.DefaultClient,
 	}
 }
+
+// SetKeys changes the value of apiKey and appKey.
+func (c *Client) SetKeys(apiKey, appKey string) {
+	c.apiKey = apiKey
+	c.appKey = appKey
+}

--- a/series.go
+++ b/series.go
@@ -22,6 +22,7 @@ type Metric struct {
 	Type   string      `json:"type,omitempty"`
 	Host   string      `json:"host,omitempty"`
 	Tags   []string    `json:"tags,omitempty"`
+	Unit   string	   `json:"unit,omitempty"`
 }
 
 // Series represents a collection of data points we get when we query for timeseries data


### PR DESCRIPTION
Related to https://github.com/DataDog/dd-go/pull/1477 which needs the extra SetKeys method to access the private apiKey and appKey members.