### PR TITLE
Refactor the request options

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ mostly used for automating dashboards/alerting and retrieving data (events, etc)
 
 The source API documentation is here: <http://docs.datadoghq.com/api/>
 
+
 ## USAGE
 
 To use this project, include it in your code like:
@@ -24,7 +25,7 @@ Then, you can work with it:
 
 ``` go
     client := datadog.NewClient("api key", "application key")
-    
+
     dash, err := client.GetDashboard(10880)
     if err != nil {
         log.Fatalf("fatal: %s\n", err)

--- a/dashboards.go
+++ b/dashboards.go
@@ -18,6 +18,10 @@ type GraphDefinitionRequest struct {
 	Stacked            bool   `json:"stacked"`
 	Aggregator         string
 	ConditionalFormats []DashboardConditionalFormat `json:"conditional_formats,omitempty"`
+	Type               string                       `json:"type,omitempty"`
+	Style              struct {
+		Palette string `json:"palette,omitempty"`
+	} `json:"style,omitempty"`
 }
 
 // Graph represents a graph that might exist on a dashboard.

--- a/dashboards.go
+++ b/dashboards.go
@@ -12,18 +12,21 @@ import (
 	"fmt"
 )
 
+// GraphDefinitionRequest represents the requests passed into each graph.
+type GraphDefinitionRequest struct {
+	Query              string `json:"q"`
+	Stacked            bool   `json:"stacked"`
+	Aggregator         string
+	ConditionalFormats []DashboardConditionalFormat `json:"conditional_formats,omitempty"`
+}
+
 // Graph represents a graph that might exist on a dashboard.
 type Graph struct {
 	Title      string     `json:"title"`
 	Events     []struct{} `json:"events"`
 	Definition struct {
-		Viz      string `json:"viz"`
-		Requests []struct {
-			Query              string `json:"q"`
-			Stacked            bool   `json:"stacked"`
-			Aggregator         string
-			ConditionalFormats []DashboardConditionalFormat `json:"conditional_formats,omitempty"`
-		} `json:"requests"`
+		Viz      string                   `json:"viz"`
+		Requests []GraphDefinitionRequest `json:"requests"`
 	} `json:"definition"`
 }
 

--- a/integration/dashboards_test.go
+++ b/integration/dashboards_test.go
@@ -126,18 +126,11 @@ func cleanUpDashboard(t *testing.T, id int) {
 	}
 }
 
-type TestGraphDefintionRequests struct {
-	Query              string `json:"q"`
-	Stacked            bool   `json:"stacked"`
-	Aggregator         string
-	ConditionalFormats []datadog.DashboardConditionalFormat `json:"conditional_formats,omitempty"`
-}
-
 func createGraph() []datadog.Graph {
 	graphDefinition := datadog.Graph{}.Definition
 	graphDefinition.Viz = "timeseries"
 	r := datadog.Graph{}.Definition.Requests
-	graphDefinition.Requests = append(r, TestGraphDefintionRequests{Query: "avg:system.mem.free{*}", Stacked: false})
+	graphDefinition.Requests = append(r, datadog.GraphDefinitionRequest{Query: "avg:system.mem.free{*}", Stacked: false})
 	graph := datadog.Graph{Title: "Mandatory graph", Definition: graphDefinition}
 	graphs := []datadog.Graph{}
 	graphs = append(graphs, graph)
@@ -148,7 +141,7 @@ func createCustomGraph() []datadog.Graph {
 	graphDefinition := datadog.Graph{}.Definition
 	graphDefinition.Viz = "query_value"
 	r := datadog.Graph{}.Definition.Requests
-	graphDefinition.Requests = append(r, TestGraphDefintionRequests{
+	graphDefinition.Requests = append(r, datadog.GraphDefinitionRequest{
 		Query:      "( sum:system.mem.used{*} / sum:system.mem.free{*} ) * 100",
 		Stacked:    false,
 		Aggregator: "avg",

--- a/integration/dashboards_test.go
+++ b/integration/dashboards_test.go
@@ -1,8 +1,9 @@
 package integration
 
 import (
-	"github.com/zorkian/go-datadog-api"
 	"testing"
+
+	"github.com/zorkian/go-datadog-api"
 )
 
 func init() {
@@ -11,6 +12,27 @@ func init() {
 
 func TestCreateAndDeleteDashboard(t *testing.T) {
 	expected := getTestDashboard(createGraph)
+	// create the dashboard and compare it
+	actual, err := client.CreateDashboard(expected)
+	if err != nil {
+		t.Fatalf("Creating a dashboard failed when it shouldn't. (%s)", err)
+	}
+
+	defer cleanUpDashboard(t, actual.Id)
+
+	assertDashboardEquals(t, actual, expected)
+
+	// now try to fetch it freshly and compare it again
+	actual, err = client.GetDashboard(actual.Id)
+	if err != nil {
+		t.Fatalf("Retrieving a dashboard failed when it shouldn't. (%s)", err)
+	}
+	assertDashboardEquals(t, actual, expected)
+
+}
+
+func TestCreateAndDeleteAdvancesTimeseriesDashboard(t *testing.T) {
+	expected := getTestDashboard(createAdvancedTimeseriesGraph)
 	// create the dashboard and compare it
 	actual, err := client.CreateDashboard(expected)
 	if err != nil {
@@ -132,6 +154,25 @@ func createGraph() []datadog.Graph {
 	r := datadog.Graph{}.Definition.Requests
 	graphDefinition.Requests = append(r, datadog.GraphDefinitionRequest{Query: "avg:system.mem.free{*}", Stacked: false})
 	graph := datadog.Graph{Title: "Mandatory graph", Definition: graphDefinition}
+	graphs := []datadog.Graph{}
+	graphs = append(graphs, graph)
+	return graphs
+}
+
+func createAdvancedTimeseriesGraph() []datadog.Graph {
+	graphDefinition := datadog.Graph{}.Definition
+	graphDefinition.Viz = "timeseries"
+	r := datadog.Graph{}.Definition.Requests
+	s := datadog.GraphDefinitionRequest{}.Style
+	s.Palette = "warm"
+
+	graphDefinition.Requests = append(r, datadog.GraphDefinitionRequest{
+		Query:   "avg:system.mem.free{*}",
+		Stacked: false,
+		Type:    "bars",
+		Style:   s,
+	})
+	graph := datadog.Graph{Title: "Custom type and style graph", Definition: graphDefinition}
 	graphs := []datadog.Graph{}
 	graphs = append(graphs, graph)
 	return graphs


### PR DESCRIPTION
In order to make some changes to the struct and not break the tests, we’d like to separate single Request into its own struct, which can be later referenced anywhere.

We've added two of some missing options in the Request struct, followed by the integration test case implementation, for this very occasion.

We've also created a [pull request](https://github.com/hashicorp/terraform/pull/9178), to the Terraform library, which would need to be merged roughly in the same time.