### PR TITLE
Move event struct into timeboard graph definition

### DIFF
--- a/dashboards.go
+++ b/dashboards.go
@@ -43,14 +43,14 @@ type GraphDefinitionMarker struct {
 
 // Graph represents a graph that might exist on a dashboard.
 type Graph struct {
-	Title  string `json:"title"`
-	Events []struct {
-		Query string `json:"q"`
-	} `json:"events"`
+	Title      string `json:"title"`
 	Definition struct {
 		Viz      string                   `json:"viz"`
 		Requests []GraphDefinitionRequest `json:"requests"`
-		Markers  []GraphDefinitionMarker  `json:"markers,omitempty"`
+		Events   []struct {
+			Query string `json:"q"`
+		} `json:"events"`
+		Markers []GraphDefinitionMarker `json:"markers,omitempty"`
 
 		// For timeseries type graphs
 		Yaxis struct {


### PR DESCRIPTION
Fixes issue with PR #60 where event struct was in base of the graph struct instead of graph.Definition.