### PR TITLE
Fixes for API inconsistency and pointers for some optional structs

### DIFF
--- a/dashboards.go
+++ b/dashboards.go
@@ -55,9 +55,9 @@ type Graph struct {
 
 		// For timeseries type graphs
 		Yaxis struct {
-			Min   float64 `json:"min,omitempty"`
-			Max   float64 `json:"max,omitempty"`
-			Scale string  `json:"scale,omitempty"`
+			Min   *float64 `json:"min,omitempty"`
+			Max   *float64 `json:"max,omitempty"`
+			Scale *string  `json:"scale,omitempty"`
 		} `json:"yaxis,omitempty"`
 
 		// For query value type graphs

--- a/dashboards.go
+++ b/dashboards.go
@@ -43,14 +43,14 @@ type GraphDefinitionMarker struct {
 
 // Graph represents a graph that might exist on a dashboard.
 type Graph struct {
-	Title  string `json:"title"`
-	Events []struct {
-		Query string `json:"q"`
-	} `json:"events"`
+	Title      string `json:"title"`
 	Definition struct {
 		Viz      string                   `json:"viz"`
 		Requests []GraphDefinitionRequest `json:"requests"`
-		Markers  []GraphDefinitionMarker  `json:"markers,omitempty"`
+		Events   []struct {
+			Query string `json:"q"`
+		} `json:"events"`
+		Markers []GraphDefinitionMarker `json:"markers,omitempty"`
 
 		// For timeseries type graphs
 		Yaxis struct {

--- a/dashboards.go
+++ b/dashboards.go
@@ -43,8 +43,10 @@ type GraphDefinitionMarker struct {
 
 // Graph represents a graph that might exist on a dashboard.
 type Graph struct {
-	Title      string     `json:"title"`
-	Events     []struct{} `json:"events"`
+	Title  string `json:"title"`
+	Events []struct {
+		Query string `json:"q"`
+	} `json:"events"`
 	Definition struct {
 		Viz      string                   `json:"viz"`
 		Requests []GraphDefinitionRequest `json:"requests"`

--- a/dashboards.go
+++ b/dashboards.go
@@ -9,6 +9,7 @@
 package datadog
 
 import (
+	"encoding/json"
 	"fmt"
 )
 
@@ -33,12 +34,12 @@ type GraphDefinitionRequest struct {
 }
 
 type GraphDefinitionMarker struct {
-	Type  string  `json:"type"`
-	Value string  `json:"value"`
-	Label string  `json:"label,omitempty"`
-	Val   float64 `json:"val,omitempty"`
-	Min   float64 `json:"min,omitempty"`
-	Max   float64 `json:"max,omitempty"`
+	Type  string      `json:"type"`
+	Value string      `json:"value"`
+	Label string      `json:"label,omitempty"`
+	Val   json.Number `json:"val,omitempty"`
+	Min   json.Number `json:"min,omitempty"`
+	Max   json.Number `json:"max,omitempty"`
 }
 
 // Graph represents a graph that might exist on a dashboard.
@@ -117,12 +118,12 @@ type reqGetDashboard struct {
 }
 
 type DashboardConditionalFormat struct {
-	Palette       string  `json:"palette,omitempty"`
-	Comparator    string  `json:"comparator,omitempty"`
-	CustomBgColor string  `json:"custom_bg_color,omitempty"`
-	Value         float64 `json:"value,omitempty"`
-	Inverted      bool    `json:"invert,omitempty"`
-	CustomFgColor string  `json:"custom_fg_color,omitempty"`
+	Palette       string      `json:"palette,omitempty"`
+	Comparator    string      `json:"comparator,omitempty"`
+	CustomBgColor string      `json:"custom_bg_color,omitempty"`
+	Value         json.Number `json:"value,omitempty"`
+	Inverted      bool        `json:"invert,omitempty"`
+	CustomFgColor string      `json:"custom_fg_color,omitempty"`
 }
 
 // GetDashboard returns a single dashboard created on this account.

--- a/dashboards.go
+++ b/dashboards.go
@@ -20,8 +20,8 @@ type GraphDefinitionRequest struct {
 	Aggregator         string
 	ConditionalFormats []DashboardConditionalFormat `json:"conditional_formats,omitempty"`
 	Type               string                       `json:"type,omitempty"`
-	Style              struct {
-		Palette string `json:"palette,omitempty"`
+	Style              *struct {
+		Palette *string `json:"palette,omitempty"`
 	} `json:"style,omitempty"`
 
 	// For change type graphs
@@ -67,9 +67,9 @@ type Graph struct {
 		CustomUnit string `json:"custom_unit,omitempty"`
 
 		// For hostnamp type graphs
-		Style struct {
-			Palette     string `json:"palette,omitempty"`
-			PaletteFlip bool   `json:"paletteFlip,omitempty"`
+		Style *struct {
+			Palette     *string `json:"palette,omitempty"`
+			PaletteFlip *bool   `json:"paletteFlip,omitempty"`
 		}
 		Groups                []string `json:"group,omitempty"`
 		IncludeNoMetricHosts  bool     `json:"noMetricHosts,omitempty"`


### PR DESCRIPTION
* Adds a complete event struct for timeboards
* Moves list of event structs into Graph.Definition (instead of in Graph directly)
* Change some instances of float64 to json.Number since in some cases Datadog API returns a number and in other cases a string.
* Change some struct attributes to pointers for optional fields