### PR TITLE
Correcting the event fields for adding an event

### DIFF
--- a/events.go
+++ b/events.go
@@ -25,10 +25,11 @@ type Event struct {
 	AlertType   string   `json:"alert_type,omitempty"`
 	Host        string   `json:"host,omitempty"`
 	Aggregation string   `json:"aggregation_key,omitempty"`
-	SourceType  string   `json:"source_type,omitempty"`
+	SourceType  string   `json:"source_type_name,omitempty"`
 	Tags        []string `json:"tags,omitempty"`
 	Url         string   `json:"url,omitempty"`
 	Resource    string   `json:"resource,omitempty"`
+	EventType   string   `json:"event_type,omitempty"`
 }
 
 // reqGetEvent is the container for receiving a single event.


### PR DESCRIPTION
The fields on "event" for pushing types and source are either missing or incorrectly named. The reference on correct naming was taken from here:

https://github.com/DataDog/dd-agent/blob/7946ff9d8f1fa4276a99d38cb53df2e67118efad/checks.d/kubernetes.py

I am trying to impersonate a type and found that setting these values correctly (in my case `kubernetes`) produced the desired results. 