### PR TITLE
Adding methods to get by name and tag.

### DIFF
--- a/monitors.go
+++ b/monitors.go
@@ -11,7 +11,9 @@ package datadog
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strconv"
+	"strings"
 )
 
 type ThresholdCount struct {
@@ -102,6 +104,36 @@ func (self *Client) GetMonitor(id int) (*Monitor, error) {
 		return nil, err
 	}
 	return &out, nil
+}
+
+// GetMonitor retrieves monitors by name
+func (self *Client) GetMonitorsByName(name string) ([]Monitor, error) {
+	var out reqMonitors
+	query, err := url.ParseQuery(fmt.Sprintf("name=%v", name))
+	if err != nil {
+		return nil, err
+	}
+
+	err = self.doJsonRequest("GET", fmt.Sprintf("/v1/monitor?%v", query.Encode()), nil, &out.Monitors)
+	if err != nil {
+		return nil, err
+	}
+	return out.Monitors, nil
+}
+
+// GetMonitor retrieves monitors by a slice of tags
+func (self *Client) GetMonitorsByTags(tags []string) ([]Monitor, error) {
+	var out reqMonitors
+	query, err := url.ParseQuery(fmt.Sprintf("monitor_tags=%v", strings.Join(tags, ",")))
+	if err != nil {
+		return nil, err
+	}
+
+	err = self.doJsonRequest("GET", fmt.Sprintf("/v1/monitor?%v", query.Encode()), nil, &out.Monitors)
+	if err != nil {
+		return nil, err
+	}
+	return out.Monitors, nil
 }
 
 // DeleteMonitor removes a monitor from the system


### PR DESCRIPTION
In order to find a monitor to prevent duplicating it, I needed some way to perform query searches by Name and/or Tag. These methods basically recreate the query you can do in the UI for monitors.

I tried to run the test suite locally, but it seemed to hang - so I did not add integration tests for these methods. However, if you need me to, I can try and get those integration tests running correctly and add additional tests for `GetMonitorsByName` and `GetMonitorsByTag`

Let me know if you need updates and I'll jump on them. I'd like to get this in the library ASAP - if you have time. :) 