### PR TITLE
make checks.go/status public as its exposed in the API

### DIFF
--- a/checks.go
+++ b/checks.go
@@ -3,16 +3,16 @@ package datadog
 type Check struct {
 	Check     string   `json:"check"`
 	HostName  string   `json:"host_name"`
-	Status    status   `json:"status"`
+	Status    Status   `json:"status"`
 	Timestamp string   `json:"timestamp,omitempty"`
 	Message   string   `json:"message,omitempty"`
 	Tags      []string `json:"tags,omitempty"`
 }
 
-type status int
+type Status int
 
 const (
-	OK status = iota
+	OK Status = iota
 	WARNING
 	CRITICAL
 	UNKNOWN


### PR DESCRIPTION
Renamed the type alias `status` to `Status` to make it public.

> Why?

Because it's exposed within the `Check` struct, yet it was private and thus people wishing to provide a function that takes a `status` value, couldn't actually do that as the type itself was private. This is pretty bad practice. When a value is exposed, its type should be exposed as well.