### PR TITLE
Add rate limit support

### DIFF
--- a/ratelimit.go
+++ b/ratelimit.go
@@ -1,0 +1,26 @@
+package datadog
+
+import (
+	"fmt"
+	"time"
+)
+
+type RateLimit struct {
+	Limit     int
+	Period    time.Duration
+	Remaining int
+	Reset     time.Duration
+}
+
+func (r *RateLimit) Error() string {
+	return fmt.Sprintf("Rate limiting: Limit %d, Period %d, Remaining %d, Reset in %d", r.Limit, r.Period, r.Remaining, r.Reset)
+}
+
+func NewRateLimit(limit, period, remaining, reset int) *RateLimit {
+	return &RateLimit{
+		Limit:     limit,
+		Period:    time.Duration(period) * time.Second,
+		Remaining: remaining,
+		Reset:     time.Duration(reset) * time.Second,
+	}
+}

--- a/request.go
+++ b/request.go
@@ -17,10 +17,18 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff"
+)
+
+const (
+	RateLimitHeader     = "X-RateLimit-Limit"
+	RatePeriodHeader    = "X-RateLimit-Period"
+	RateRemainingHeader = "X-RateLimit-Remaining"
+	RateResetHeader     = "X-RateLimit-Reset"
 )
 
 // uriForAPI is to be called with something like "/v1/events" and it will give
@@ -73,6 +81,12 @@ func (client *Client) doJsonRequest(method, api string,
 	}
 	defer resp.Body.Close()
 
+	if err := client.getRateLimit(resp); err != nil {
+		if err.(*RateLimit).Remaining == 0 {
+			return err
+		}
+	}
+
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
@@ -104,6 +118,27 @@ func (client *Client) doJsonRequest(method, api string,
 	return nil
 }
 
+func (client *Client) getRateLimit(response *http.Response) error {
+
+	ratelimit := response.Header.Get(RateLimitHeader)
+	if ratelimit == "" {
+		return nil
+	}
+
+	rateperiod := response.Header.Get(RatePeriodHeader)
+	rateremaining := response.Header.Get(RateRemainingHeader)
+	ratereset := response.Header.Get(RateResetHeader)
+
+	limit, _ := strconv.Atoi(ratelimit)
+	period, _ := strconv.Atoi(rateperiod)
+	remaining, _ := strconv.Atoi(rateremaining)
+	reset, _ := strconv.Atoi(ratereset)
+
+	ratelimiterror := NewRateLimit(limit, period, remaining, reset)
+
+	return error(ratelimiterror)
+}
+
 // doRequestWithRetries performs an HTTP request repeatedly for maxTime or until
 // no error and no HTTP response code higher than 299 is returned.
 func (client *Client) doRequestWithRetries(req *http.Request, maxTime time.Duration) (*http.Response, error) {
@@ -118,6 +153,12 @@ func (client *Client) doRequestWithRetries(req *http.Request, maxTime time.Durat
 		resp, err = client.HttpClient.Do(req)
 		if err != nil {
 			return err
+		}
+
+		if err := client.getRateLimit(resp); err != nil {
+			if err.(*RateLimit).Remaining == 0 {
+				return err
+			}
 		}
 
 		if resp.StatusCode < 200 || resp.StatusCode > 299 {


### PR DESCRIPTION
This will return back a error if the rate limiting is down to 0. On some APIs datadog will rate limit and it doesnt make sense to keep trying. This will also return it back as a error. Im not sure if this is good or bad. I feel like it should come back as `data, ratelimit, err := client.QueryMetrics...`

Currently the way this will work is on either doRequest or doRequestWithRetries it will check for the header if it has it and returns back a error it will then check the remaining if it is at 0 it will then return the rate limit error as a error type.

The above should be fine and give the user some information. I should probably also update the doc strings for the 4ish endpoints that I know have rate limiting via the datadog api.