### PR TITLE
Use vendored assert

### DIFF
--- a/integration/client_test.go
+++ b/integration/client_test.go
@@ -3,8 +3,8 @@ package integration
 import (
 	"testing"
 
-	"github.com/docker/docker/pkg/testutil/assert"
 	"github.com/zorkian/go-datadog-api"
+	"github.com/stretchr/testify/assert"
 )
 
 func init() {


### PR DESCRIPTION
 Accidentally used the Docker assert package instead of the already vendored testify package.
