### PR TITLE
Fix dashboard acceptance tests

### DIFF
--- a/dashboards.go
+++ b/dashboards.go
@@ -13,6 +13,13 @@ import (
 	"fmt"
 )
 
+// GraphDefinitionRequestStyle represents the graph style attributes
+type GraphDefinitionRequestStyle struct {
+	Palette *string `json:"palette,omitempty"`
+	Width   *string `json:"width,omitempty"`
+	Type    *string `json:"type,omitempty"`
+}
+
 // GraphDefinitionRequest represents the requests passed into each graph.
 type GraphDefinitionRequest struct {
 	Query              string `json:"q"`
@@ -20,11 +27,7 @@ type GraphDefinitionRequest struct {
 	Aggregator         string
 	ConditionalFormats []DashboardConditionalFormat `json:"conditional_formats,omitempty"`
 	Type               string                       `json:"type,omitempty"`
-	Style              *struct {
-		Palette *string `json:"palette,omitempty"`
-		Width   *string `json:"width,omitempty"`
-		Type    *string `json:"type,omitempty"`
-	} `json:"style,omitempty"`
+	Style              *GraphDefinitionRequestStyle `json:"style,omitempty"`
 
 	// For change type graphs
 	ChangeType     string `json:"change_type,omitempty"`

--- a/integration/dashboards_test.go
+++ b/integration/dashboards_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/zorkian/go-datadog-api"
@@ -163,14 +164,13 @@ func createAdvancedTimeseriesGraph() []datadog.Graph {
 	graphDefinition := datadog.Graph{}.Definition
 	graphDefinition.Viz = "timeseries"
 	r := datadog.Graph{}.Definition.Requests
-	s := datadog.GraphDefinitionRequest{}.Style
-	s.Palette = "warm"
+	pallette := "warm"
 
 	graphDefinition.Requests = append(r, datadog.GraphDefinitionRequest{
 		Query:   "avg:system.mem.free{*}",
 		Stacked: false,
 		Type:    "bars",
-		Style:   s,
+		Style:   &datadog.GraphDefinitionRequestStyle{Palette: &pallette},
 	})
 	graph := datadog.Graph{Title: "Custom type and style graph", Definition: graphDefinition}
 	graphs := []datadog.Graph{}
@@ -189,15 +189,15 @@ func createCustomGraph() []datadog.Graph {
 		ConditionalFormats: []datadog.DashboardConditionalFormat{
 			{
 				Comparator: ">",
-				Value:      99.9,
+				Value:      json.Number("99.9"),
 				Palette:    "white_on_green"},
 			{
 				Comparator: ">=",
-				Value:      99,
+				Value:      json.Number("99"),
 				Palette:    "white_on_yellow"},
 			{
 				Comparator: "<",
-				Value:      99,
+				Value:      json.Number("99"),
 				Palette:    "white_on_red"}}})
 	graph := datadog.Graph{Title: "Mandatory graph 2", Definition: graphDefinition}
 	graphs := []datadog.Graph{}


### PR DESCRIPTION
Weren't up-to-date with the defined API resulting in the following errors:

```
# command-line-arguments
integration/dashboards_test.go:167: cannot use "warm" (type string) as type *string in assignment
integration/dashboards_test.go:192: cannot use 99.9 (type float64) as type json.Number in field value
integration/dashboards_test.go:196: cannot use 99 (type int) as type json.Number in field value
integration/dashboards_test.go:200: cannot use 99 (type int) as type json.Number in field value
FAIL    command-line-arguments [build failed]
```

As a result of #62 which changed the `datadog.GraphDefinitionRequest` to use a pointer for `Style`, it seemed prudent to break this out into a separate struct to make it easier for people to initialize (just fixing the above compilation errors ended up causing a null pointer panic in `TestCreateAndDeleteAdvancesTimeseriesDashboard`.