### PR TITLE
Add support for new_host_delay in monitor definitions

### DIFF
--- a/convert_types.go
+++ b/convert_types.go
@@ -1,0 +1,8 @@
+package datadog
+
+func Int(val interface{}) *int {
+	if ival, ok := val.(int); ok {
+		return &ival
+	}
+	return nil
+}

--- a/convert_types.go
+++ b/convert_types.go
@@ -1,8 +1,15 @@
 package datadog
 
-func Int(val interface{}) *int {
-	if ival, ok := val.(int); ok {
-		return &ival
+// Int is a helper routine that allocates a new int value
+// to store v and returns a pointer to it.
+func Int(v int) *int { return &v }
+
+// GetInt is a helper routine that returns a boolean representing
+// if a value was set, and if so, dereferences the pointer to it.
+func GetInt(v *int) (int, bool) {
+	if v != nil {
+		return *v, true
 	}
-	return nil
+
+	return 0, false
 }

--- a/integration/client_test.go
+++ b/integration/client_test.go
@@ -3,8 +3,8 @@ package integration
 import (
 	"testing"
 
-	"github.com/zorkian/go-datadog-api"
 	"github.com/stretchr/testify/assert"
+	"github.com/zorkian/go-datadog-api"
 )
 
 func init() {

--- a/integration/monitors_test.go
+++ b/integration/monitors_test.go
@@ -1,9 +1,10 @@
 package integration
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/zorkian/go-datadog-api"
-	"testing"
 )
 
 func init() {
@@ -116,6 +117,7 @@ func getTestMonitor() *datadog.Monitor {
 	o := datadog.Options{
 		NotifyNoData:    true,
 		NoDataTimeframe: 60,
+		NewHostDelay:    datadog.Int(600),
 		Silenced:        map[string]int{},
 	}
 

--- a/monitors.go
+++ b/monitors.go
@@ -42,6 +42,7 @@ type Options struct {
 	NoDataTimeframe   NoDataTimeframe `json:"no_data_timeframe,omitempty"`
 	NotifyAudit       bool            `json:"notify_audit,omitempty"`
 	NotifyNoData      bool            `json:"notify_no_data,omitempty"`
+	NewHostDelay      *int            `json:"new_host_delay,omitempty"`
 	RenotifyInterval  int             `json:"renotify_interval,omitempty"`
 	Silenced          map[string]int  `json:"silenced,omitempty"`
 	TimeoutH          int             `json:"timeout_h,omitempty"`


### PR DESCRIPTION
This field defaults to 300 if empty, but we also need to support setting
it to 0 so I chose to use a *int pointer.

I stumbled upon #56 which discussed the use of pointers to support optional fields which seemed to be leaning towards the approach I took here, but let me know what you think.

`TestCreateAndDeleteMonitor` is failing locally for me, showing a diff including:

```
                        -  Handle: (string) "",
                        -  Id: (int) 0,
                        -  Name: (string) ""
                        +  Email: (string) (len=30) "jesse.szwedko@getbraintree.com",
                        +  Handle: (string) (len=30) "jesse.szwedko@getbraintree.com",
                        +  Id: (int) 222578,
                        +  Name: (string) (len=13) "Jesse Szwedko"
```

I can dig in more, but this also fails on master (first including the changes from #81) so I'm hoping I'm just doing something wrong when running the tests.