### PR TITLE
Allow null for new_host_delay

### DIFF
--- a/monitors.go
+++ b/monitors.go
@@ -42,7 +42,7 @@ type Options struct {
 	NoDataTimeframe   NoDataTimeframe `json:"no_data_timeframe,omitempty"`
 	NotifyAudit       bool            `json:"notify_audit,omitempty"`
 	NotifyNoData      bool            `json:"notify_no_data,omitempty"`
-	NewHostDelay      *int            `json:"new_host_delay,omitempty"`
+	NewHostDelay      *int            `json:"new_host_delay"`
 	RenotifyInterval  int             `json:"renotify_interval,omitempty"`
 	Silenced          map[string]int  `json:"silenced,omitempty"`
 	TimeoutH          int             `json:"timeout_h,omitempty"`


### PR DESCRIPTION
Otherwise there isn't a great way to tell the monitor to fall back to the Datadog default (currently 300s) as Datadog treats the absence of the key different from the presence of the key with `null` as the value.