### PR TITLE
[series] add support for metrics unit

### DIFF
--- a/series.go
+++ b/series.go
@@ -22,6 +22,7 @@ type Metric struct {
 	Type   string      `json:"type,omitempty"`
 	Host   string      `json:"host,omitempty"`
 	Tags   []string    `json:"tags,omitempty"`
+	Unit   string	   `json:"unit,omitempty"`
 }
 
 // Series represents a collection of data points we get when we query for timeseries data


### PR DESCRIPTION
When submitting a datapoint, one can also submit a "unit" information that will be used to update metrics metadata and eventually what's displayed on the UI.

Related docs:
* http://docs.datadoghq.com/units/
* https://help.datadoghq.com/hc/en-us/articles/204580889-How-can-I-set-up-custom-units-for-custom-metrics-

To also respond to #88, we initially forked to hack on top of the lib for an internal project at Datadog and we had plans to submit upstream but just did not follow through. We are really thankful for all the great work putting together this lib, we are heavy users now :bowing_man: . Once merged, we can pin the newer version upstream in our codebase and remove the fork :)