### PR TITLE
[client] add setter to modify API/application keys.

### DIFF
--- a/client.go
+++ b/client.go
@@ -44,6 +44,12 @@ func NewClient(apiKey, appKey string) *Client {
 	}
 }
 
+// SetKeys changes the value of apiKey and appKey.
+func (c *Client) SetKeys(apiKey, appKey string) {
+	c.apiKey = apiKey
+	c.appKey = appKey
+}
+
 // Validate checks if the API and application keys are valid.
 func (client *Client) Validate() (bool, error) {
 	var bodyreader io.Reader


### PR DESCRIPTION
disclaimer: This might be a slightly overkill scenario for most users.
But as we were using this library for an internal project, we needed the same program to be able to submit data for multiple Datadog accounts.
This just adds a setter to the client, so that we can have a pool of Clients and re-use them by changing  credentials on the fly (no need for other resource reallocations).

Also echoes #88 :)