### PR TITLE
Add Downtime.MonitorId and Monitor.Options.EvaluationDelay

### DIFF
--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -8011,6 +8011,37 @@ func (o *Options) SetEscalationMessage(v string) {
 	o.EscalationMessage = &v
 }
 
+// GetEvaluationDelay returns the EvaluationDelay field if non-nil, zero value otherwise.
+func (o *Options) GetEvaluationDelay() int {
+	if o == nil || o.EvaluationDelay == nil {
+		return 0
+	}
+	return *o.EvaluationDelay
+}
+
+// GetOkEvaluationDelay returns a tuple with the EvaluationDelay field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (o *Options) GetEvaluationDelayOk() (int, bool) {
+	if o == nil || o.EvaluationDelay == nil {
+		return 0, false
+	}
+	return *o.EvaluationDelay, true
+}
+
+// HasEvaluationDelay returns a boolean if a field has been set.
+func (o *Options) HasEvaluationDelay() bool {
+	if o != nil && o.EvaluationDelay != nil {
+		return true
+	}
+
+	return false
+}
+
+// GetEvaluationDelay allocates a new o.EvaluationDelay and returns the pointer to it.
+func (o *Options) SetEvaluationDelay(v int) {
+	o.EvaluationDelay = &v
+}
+
 // GetIncludeTags returns the IncludeTags field if non-nil, zero value otherwise.
 func (o *Options) GetIncludeTags() bool {
 	if o == nil || o.IncludeTags == nil {

--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -3175,6 +3175,37 @@ func (d *Downtime) SetMessage(v string) {
 	d.Message = &v
 }
 
+// GetMonitorId returns the MonitorId field if non-nil, zero value otherwise.
+func (d *Downtime) GetMonitorId() int {
+	if d == nil || d.MonitorId == nil {
+		return 0
+	}
+	return *d.MonitorId
+}
+
+// GetOkMonitorId returns a tuple with the MonitorId field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (d *Downtime) GetMonitorIdOk() (int, bool) {
+	if d == nil || d.MonitorId == nil {
+		return 0, false
+	}
+	return *d.MonitorId, true
+}
+
+// HasMonitorId returns a boolean if a field has been set.
+func (d *Downtime) HasMonitorId() bool {
+	if d != nil && d.MonitorId != nil {
+		return true
+	}
+
+	return false
+}
+
+// GetMonitorId allocates a new d.MonitorId and returns the pointer to it.
+func (d *Downtime) SetMonitorId(v int) {
+	d.MonitorId = &v
+}
+
 // GetRecurrence returns the Recurrence field if non-nil, zero value otherwise.
 func (d *Downtime) GetRecurrence() Recurrence {
 	if d == nil || d.Recurrence == nil {

--- a/downtimes.go
+++ b/downtimes.go
@@ -26,6 +26,7 @@ type Downtime struct {
 	Disabled   *bool       `json:"disabled,omitempty"`
 	End        *int        `json:"end,omitempty"`
 	Id         *int        `json:"id,omitempty"`
+	MonitorId  *int        `json:"monitor_id,omitempty"`
 	Message    *string     `json:"message,omitempty"`
 	Recurrence *Recurrence `json:"recurrence,omitempty"`
 	Scope      []string    `json:"scope,omitempty"`

--- a/integration/downtime_test.go
+++ b/integration/downtime_test.go
@@ -42,7 +42,6 @@ func TestDowntimeLinkedToMonitorCreateAndDelete(t *testing.T) {
 		t.Fatalf("Creating a downtime failed when it shouldn't: %s", err)
 	}
 
-	// Set ID of our original struct to zero so we can easily compare the results
 	expected.SetId(downtime.GetId())
 
 	assert.Equal(t, expected, downtime)

--- a/integration/downtime_test.go
+++ b/integration/downtime_test.go
@@ -1,9 +1,10 @@
 package integration
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/zorkian/go-datadog-api"
-	"testing"
 )
 
 func init() {
@@ -22,6 +23,31 @@ func TestDowntimeCreateAndDelete(t *testing.T) {
 	assert.Equal(t, expected, actual)
 
 	actual, err := client.GetDowntime(*actual.Id)
+	if err != nil {
+		t.Fatalf("Retrieving a downtime failed when it shouldn't: (%s)", err)
+	}
+	assert.Equal(t, expected, actual)
+}
+
+func TestDowntimeLinkedToMonitorCreateAndDelete(t *testing.T) {
+	monitor := createTestMonitor(t)
+	defer cleanUpMonitor(t, monitor.GetId())
+
+	expected := getTestDowntime()
+	expected.SetMonitorId(monitor.GetId())
+
+	downtime, err := client.CreateDowntime(expected)
+	defer cleanUpDowntime(t, downtime.GetId())
+	if err != nil {
+		t.Fatalf("Creating a downtime failed when it shouldn't: %s", err)
+	}
+
+	// Set ID of our original struct to zero so we can easily compare the results
+	expected.SetId(downtime.GetId())
+
+	assert.Equal(t, expected, downtime)
+
+	actual, err := client.GetDowntime(downtime.GetId())
 	if err != nil {
 		t.Fatalf("Retrieving a downtime failed when it shouldn't: (%s)", err)
 	}

--- a/integration/monitors_test.go
+++ b/integration/monitors_test.go
@@ -116,12 +116,13 @@ func TestMonitorMuteUnmute(t *testing.T) {
 func getTestMonitor() *datadog.Monitor {
 
 	o := &datadog.Options{
-		NotifyNoData:    datadog.Bool(true),
-		NotifyAudit:     datadog.Bool(false),
-		Locked:          datadog.Bool(false),
-		NoDataTimeframe: 60,
-		NewHostDelay:    datadog.Int(600),
-		Silenced:        map[string]int{},
+		NotifyNoData:      datadog.Bool(true),
+		NotifyAudit:       datadog.Bool(false),
+		Locked:            datadog.Bool(false),
+		NoDataTimeframe:   60,
+		NewHostDelay:      datadog.Int(600),
+		RequireFullWindow: datadog.Bool(true),
+		Silenced:          map[string]int{},
 	}
 
 	return &datadog.Monitor{

--- a/monitors.go
+++ b/monitors.go
@@ -44,6 +44,7 @@ type Options struct {
 	NotifyNoData      *bool           `json:"notify_no_data,omitempty"`
 	RenotifyInterval  *int            `json:"renotify_interval,omitempty"`
 	NewHostDelay      *int            `json:"new_host_delay,omitempty"`
+	EvaluationDelay   *int            `json:"evaluation_delay,omitempty"`
 	Silenced          map[string]int  `json:"silenced,omitempty"`
 	TimeoutH          *int            `json:"timeout_h,omitempty"`
 	EscalationMessage *string         `json:"escalation_message,omitempty"`


### PR DESCRIPTION
This adds the ability to create downtime windows attached to specific monitors, and set the evaluation_delay option on monitors.

We have an open ticket with datadog to document sending monitor_id to downtime. It's missing from the create/update docs. It shows monitor_id as coming back in the response.

We also have a ticket with datadog to put the evaluation_delay option in their docs.

I took a shot at adding an acceptance test to make sure a downtime could attach a monitor.

Thanks!