### PR TITLE
use map[string]string to pass query options for snapshot

### DIFF
--- a/integration/snapshot_test.go
+++ b/integration/snapshot_test.go
@@ -1,0 +1,59 @@
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func Jsonify(v interface{}) (string, error) {
+	if b, err := json.MarshalIndent(v, "", " "); err != nil {
+		return "", err
+	} else {
+		return string(b), nil
+	}
+}
+
+func init() {
+	client = initTest()
+}
+
+func TestSnapshot(t *testing.T) {
+
+	end := time.Now().Unix()
+	start := end - 3600
+
+	query_s := "avg:system.mem.used{*}"
+	url, err := client.Snapshot(query_s, time.Unix(start, 0), time.Unix(end, 0), "")
+
+	if err != nil {
+		t.Fatalf("Couldn't create snapshot for query(%s): %s", query_s, err)
+	}
+
+	fmt.Printf("query snapshot url: %s\n", url)
+}
+
+func TestSnapshotGeneric(t *testing.T) {
+
+	end := time.Now().Unix()
+	start := end - 3600
+
+	// create new graph def
+	graphs := createCustomGraph()
+
+	graph_def, err := Jsonify(graphs[0].Definition)
+	if err != nil {
+		t.Fatalf("Couldn't create graph_def: %s", err)
+	}
+
+	options := map[string]string{"graph_def": graph_def}
+
+	url, err := client.SnapshotGeneric(options, time.Unix(start, 0), time.Unix(end, 0))
+
+	if err != nil {
+		t.Fatalf("Couldn't create snapshot from graph_def(%s): %s", graph_def, err)
+	}
+
+	fmt.Printf("Graph def snapshot url: %s\n", url)
+}

--- a/snapshot.go
+++ b/snapshot.go
@@ -15,12 +15,14 @@ import (
 )
 
 // Snapshot creates an image from a graph and returns the URL of the image.
-func (client *Client) Snapshot(query string, start, end time.Time, eventQuery string) (string, error) {
+func (client *Client) Snapshot(options map[string]string, start, end time.Time) (string, error) {
 	v := url.Values{}
 	v.Add("start", fmt.Sprintf("%d", start.Unix()))
 	v.Add("end", fmt.Sprintf("%d", end.Unix()))
-	v.Add("metric_query", query)
-	v.Add("event_query", eventQuery)
+
+	for opt, val := range options {
+		v.Add(opt, val)
+	}
 
 	out := struct {
 		SnapshotURL string `json:"snapshot_url,omitempty"`

--- a/snapshot.go
+++ b/snapshot.go
@@ -14,8 +14,25 @@ import (
 	"time"
 )
 
+func (client *Client) doSnapshotRequest(values url.Values) (string, error) {
+	out := struct {
+		SnapshotURL string `json:"snapshot_url,omitempty"`
+	}{}
+	if err := client.doJsonRequest("GET", "/v1/graph/snapshot?"+values.Encode(), nil, &out); err != nil {
+		return "", err
+	}
+	return out.SnapshotURL, nil
+}
+
 // Snapshot creates an image from a graph and returns the URL of the image.
-func (client *Client) Snapshot(options map[string]string, start, end time.Time) (string, error) {
+func (client *Client) Snapshot(query string, start, end time.Time, eventQuery string) (string, error) {
+	options := map[string]string{"metric_query": query, "event_query": eventQuery}
+
+	return client.SnapshotGeneric(options, start, end)
+}
+
+// Generic function for snapshots, use map[string]string to create url.Values() instead of pre-defined params
+func (client *Client) SnapshotGeneric(options map[string]string, start, end time.Time) (string, error) {
 	v := url.Values{}
 	v.Add("start", fmt.Sprintf("%d", start.Unix()))
 	v.Add("end", fmt.Sprintf("%d", end.Unix()))
@@ -24,11 +41,5 @@ func (client *Client) Snapshot(options map[string]string, start, end time.Time) 
 		v.Add(opt, val)
 	}
 
-	out := struct {
-		SnapshotURL string `json:"snapshot_url,omitempty"`
-	}{}
-	if err := client.doJsonRequest("GET", "/v1/graph/snapshot?"+v.Encode(), nil, &out); err != nil {
-		return "", err
-	}
-	return out.SnapshotURL, nil
+	return client.doSnapshotRequest(v)
 }


### PR DESCRIPTION
 * wanted to use graph_def instead of query_metric argument
 * make making snapshots of dashboards much simplier -> GetDashboard() -> Graphs[i].GraphDefinition -> Jsonify() (not in this repo) and query using output JSON