### PR TITLE
Fix metric metadata

### DIFF
--- a/metric_metadata.go
+++ b/metric_metadata.go
@@ -23,7 +23,7 @@ type MetricMetadata struct {
 // ViewMetricMetadata allows you to get metadata about a specific metric.
 func (client *Client) ViewMetricMetadata(mn string) (*MetricMetadata, error) {
 	var out MetricMetadata
-	if err := client.doJsonRequest("GET", fmt.Sprintf("/api/v1/metrics/%s", mn), nil, &out); err != nil {
+	if err := client.doJsonRequest("GET", fmt.Sprintf("/v1/metrics/%s", mn), nil, &out); err != nil {
 		return nil, err
 	}
 	return &out, nil
@@ -32,7 +32,7 @@ func (client *Client) ViewMetricMetadata(mn string) (*MetricMetadata, error) {
 // EditMetricMetadata edits the metadata for the given metric.
 func (client *Client) EditMetricMetadata(mn string, mm *MetricMetadata) (*MetricMetadata, error) {
 	var out MetricMetadata
-	if err := client.doJsonRequest("PUT", fmt.Sprintf("/api/v1/metrics/%s", mn), mm, &out); err != nil {
+	if err := client.doJsonRequest("PUT", fmt.Sprintf("/v1/metrics/%s", mn), mm, &out); err != nil {
 		return nil, err
 	}
 	return &out, nil


### PR DESCRIPTION
- The urls were starting as /api/api/... and giving 404s

Can you make a release after merging so I can use the update in my PR for the terraform provider? 

Thanks @zorkian 