### PR TITLE
hosts: Add Host Muting/Unmuting capability

### DIFF
--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -5996,6 +5996,99 @@ func (g *GraphWidget) SetY(v int) {
 	g.Y = &v
 }
 
+// GetEndTime returns the EndTime field if non-nil, zero value otherwise.
+func (h *HostActionMute) GetEndTime() string {
+	if h == nil || h.EndTime == nil {
+		return ""
+	}
+	return *h.EndTime
+}
+
+// GetOkEndTime returns a tuple with the EndTime field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (h *HostActionMute) GetEndTimeOk() (string, bool) {
+	if h == nil || h.EndTime == nil {
+		return "", false
+	}
+	return *h.EndTime, true
+}
+
+// HasEndTime returns a boolean if a field has been set.
+func (h *HostActionMute) HasEndTime() bool {
+	if h != nil && h.EndTime != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetEndTime allocates a new h.EndTime and returns the pointer to it.
+func (h *HostActionMute) SetEndTime(v string) {
+	h.EndTime = &v
+}
+
+// GetMessage returns the Message field if non-nil, zero value otherwise.
+func (h *HostActionMute) GetMessage() string {
+	if h == nil || h.Message == nil {
+		return ""
+	}
+	return *h.Message
+}
+
+// GetOkMessage returns a tuple with the Message field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (h *HostActionMute) GetMessageOk() (string, bool) {
+	if h == nil || h.Message == nil {
+		return "", false
+	}
+	return *h.Message, true
+}
+
+// HasMessage returns a boolean if a field has been set.
+func (h *HostActionMute) HasMessage() bool {
+	if h != nil && h.Message != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetMessage allocates a new h.Message and returns the pointer to it.
+func (h *HostActionMute) SetMessage(v string) {
+	h.Message = &v
+}
+
+// GetOverride returns the Override field if non-nil, zero value otherwise.
+func (h *HostActionMute) GetOverride() bool {
+	if h == nil || h.Override == nil {
+		return false
+	}
+	return *h.Override
+}
+
+// GetOkOverride returns a tuple with the Override field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (h *HostActionMute) GetOverrideOk() (bool, bool) {
+	if h == nil || h.Override == nil {
+		return false, false
+	}
+	return *h.Override, true
+}
+
+// HasOverride returns a boolean if a field has been set.
+func (h *HostActionMute) HasOverride() bool {
+	if h != nil && h.Override != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetOverride allocates a new h.Override and returns the pointer to it.
+func (h *HostActionMute) SetOverride(v bool) {
+	h.Override = &v
+}
+
 // GetHeight returns the Height field if non-nil, zero value otherwise.
 func (h *HostMapWidget) GetHeight() int {
 	if h == nil || h.Height == nil {

--- a/hosts.go
+++ b/hosts.go
@@ -1,0 +1,33 @@
+package datadog
+
+type HostActionResp struct {
+	Action   string `json:"action"`
+	Hostname string `json:"hostname"`
+	Message  string `json:"message,omitempty"`
+}
+
+type HostActionMute struct {
+	Message  *string `json:"message,omitempty"`
+	EndTime  *string `json:"end,omitempty"`
+	Override *bool   `json:"override,omitempty"`
+}
+
+// MuteHost mutes all monitors for the given host
+func (client *Client) MuteHost(host string, action *HostActionMute) (*HostActionResp, error) {
+	var out HostActionResp
+	uri := "/v1/host/" + host + "/mute"
+	if err := client.doJsonRequest("POST", uri, action, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// UnmuteHost unmutes all monitors for the given host
+func (client *Client) UnmuteHost(host string) (*HostActionResp, error) {
+	var out HostActionResp
+	uri := "/v1/host/" + host + "/unmute"
+	if err := client.doJsonRequest("POST", uri, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/integration/hosts_test.go
+++ b/integration/hosts_test.go
@@ -1,0 +1,45 @@
+package integration
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	datadog "github.com/zorkian/go-datadog-api"
+)
+
+func init() {
+	client = initTest()
+}
+
+func TestHost_Mute(t *testing.T) {
+	muteAction := getTestMuteAction()
+	hostname := "test.host"
+	muteResp, err := client.MuteHost(hostname, muteAction)
+	if err != nil {
+		t.Fatalf("Failed to mute host: %s, err: %s", hostname, err)
+	}
+
+	defer func() {
+		unmuteResp, err := client.UnmuteHost(hostname)
+		if err != nil {
+			t.Fatalf("Failed to cleanup mute on host: %s, err: %s", hostname, err)
+		}
+		assert.Equal(t, "Unmuted", unmuteResp.Action)
+		assert.Equal(t, hostname, unmuteResp.Hostname)
+	}()
+
+	assert.Equal(t, "Muted", muteResp.Action)
+	assert.Equal(t, hostname, muteResp.Hostname)
+	assert.Equal(t, "Muting this host for a test!", muteResp.Message)
+
+}
+
+func getTestMuteAction() *datadog.HostActionMute {
+	return &datadog.HostActionMute{
+		Message:  datadog.String("Muting this host for a test!"),
+		EndTime:  datadog.String(fmt.Sprint(time.Now().Unix() + 100)),
+		Override: datadog.Bool(false),
+	}
+}


### PR DESCRIPTION
This implements the following:

Muting a host: https://docs.datadoghq.com/api/?lang=console#hosts-mute
Unmuting a host: https://docs.datadoghq.com/api/?lang=console#hosts-unmute

Included with this commit is an integration test for the API.

Signed-off-by: Simarpreet Singh <simar@linux.com>