### PR TITLE
Accept "null" in monitor NoDataTimeframe

### DIFF
--- a/monitors.go
+++ b/monitors.go
@@ -26,7 +26,7 @@ type NoDataTimeframe int
 
 func (tf *NoDataTimeframe) UnmarshalJSON(data []byte) error {
 	s := string(data)
-	if s == "false" {
+	if s == "false" || s == "null" {
 		*tf = 0
 	} else {
 		i, err := strconv.ParseInt(s, 10, 32)


### PR DESCRIPTION
## Why

If the monitor is configured _not_ to notify data missing, GetMonitor API returns `null` in `no_data_timeframe` field.
Therefore `NoDataTimeframe.UnmarshalJSON` tries to parse `"null"` as `Int`, then it returns error.

### how to reproduce

```go
package main

import (
	"os"

	"github.com/k0kubun/pp"
	"github.com/zorkian/go-datadog-api"
)

const (
	monitorID = 123456 // your monitor ID which does not notify data missing
)

func main() {
	apiKey, appKey := os.Getenv("DATADOG_API_KEY"), os.Getenv("DATADOG_APP_KEY")
	client := datadog.NewClient(apiKey, appKey)

	mon, err := client.GetMonitor(monitorID)
	if err != nil {
		panic(err)
	}

	pp.Println(mon)
}
```

```sh-session
$ go run hoge.go
panic: strconv.ParseInt: parsing "null": invalid syntax

goroutine 1 [running]:
main.main()
        /Users/dtan4/src/github.com/dtan4/terraforming-datadog/hoge.go:20 +0x1e1
exit status 2
```

## What

Accept `nil` in `no_data_timeframe` and return empty value.