### PR TITLE
Read HTTP resp body so conn can be reused immediately

### DIFF
--- a/request.go
+++ b/request.go
@@ -83,6 +83,8 @@ func (client *Client) doJsonRequest(method, api string,
 	// If they don't care about the body, then we don't care to give them one,
 	// so bail out because we're done.
 	if out == nil {
+		// read the response body so http conn can be reused immediately
+		io.Copy(ioutil.Discard, resp.Body)
 		return nil
 	}
 


### PR DESCRIPTION
see https://golang.org/pkg/net/http/#Response

// The http Client and Transport guarantee that Body is always
// non-nil, even on responses without a body or responses with
// a zero-length body. It is the caller's responsibility to
// close Body. The default HTTP client's Transport does not
// attempt to reuse HTTP/1.0 or HTTP/1.1 TCP connections
// ("keep-alive") unless the Body is read to completion and is
// closed.