### PR TITLE
Allow monitor tags to be removed on update

### DIFF
--- a/monitors.go
+++ b/monitors.go
@@ -66,7 +66,7 @@ type Monitor struct {
 	Query   *string  `json:"query,omitempty"`
 	Name    *string  `json:"name,omitempty"`
 	Message *string  `json:"message,omitempty"`
-	Tags    []string `json:"tags,omitempty"`
+	Tags    []string `json:"tags"`
 	Options *Options `json:"options,omitempty"`
 }
 


### PR DESCRIPTION
# Issue

* You create a monitor that has tags
* You remove the tags from the monitor and call `UpdateMonitor`
* The monitor's tags are not updated as an empty `tags` isn't passed to the DataDog API due to it being omitted in the `Monitor` struct when marshalling to JSON

# Fix

* Changed the `Monitor` struct to not omit empty `tags` when marshalling to JSON