### PR TITLE
Add Unit extraction to the query get api

### DIFF
--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -10212,6 +10212,37 @@ func (s *Series) SetStart(v float64) {
 	s.Start = &v
 }
 
+// GetUnits returns the Units field if non-nil, zero value otherwise.
+func (s *Series) GetUnits() UnitPair {
+	if s == nil || s.Units == nil {
+		return UnitPair{}
+	}
+	return *s.Units
+}
+
+// GetOkUnits returns a tuple with the Units field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (s *Series) GetUnitsOk() (UnitPair, bool) {
+	if s == nil || s.Units == nil {
+		return UnitPair{}, false
+	}
+	return *s.Units, true
+}
+
+// HasUnits returns a boolean if a field has been set.
+func (s *Series) HasUnits() bool {
+	if s != nil && s.Units != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetUnits allocates a new s.Units and returns the pointer to it.
+func (s *Series) SetUnits(v UnitPair) {
+	s.Units = &v
+}
+
 // GetPalette returns the Palette field if non-nil, zero value otherwise.
 func (s *Style) GetPalette() string {
 	if s == nil || s.Palette == nil {

--- a/series.go
+++ b/series.go
@@ -31,6 +31,7 @@ type Metric struct {
 // Unit represents a unit definition that we might receive when query for timeseries data.
 // A metric is characterized by 2 units as: x per y
 // One or both could be missing
+type UnitPair *[2]*Unit
 type Unit struct {
 	Family string       `json:"family"`
 	ScaleFactor float32 `json:"scale_factor"`
@@ -52,7 +53,7 @@ type Series struct {
 	Length      *int        `json:"length,omitempty"`
 	Scope       *string     `json:"scope,omitempty"`
 	Expression  *string     `json:"expression,omitempty"`
-	Units       *[2]*Unit   `json:"unit"`
+	Units       UnitPair    `json:"unit"`
 }
 
 // reqPostSeries from /api/v1/series

--- a/series.go
+++ b/series.go
@@ -29,9 +29,6 @@ type Metric struct {
 }
 
 // Unit represents a unit definition that we might receive when query for timeseries data.
-// A metric is characterized by 2 units as: x per y
-// One or both could be missing
-type UnitPair *[2]*Unit
 type Unit struct {
 	Family string       `json:"family"`
 	ScaleFactor float32 `json:"scale_factor"`
@@ -40,6 +37,10 @@ type Unit struct {
 	Plural string       `json:"plural"`
 	Id int              `json:"id"`
 }
+
+// A Series is characterized by 2 units as: x per y
+// One or both could be missing
+type UnitPair []*Unit
 
 // Series represents a collection of data points we get when we query for timeseries data
 type Series struct {
@@ -53,7 +54,7 @@ type Series struct {
 	Length      *int        `json:"length,omitempty"`
 	Scope       *string     `json:"scope,omitempty"`
 	Expression  *string     `json:"expression,omitempty"`
-	Units       UnitPair    `json:"unit"`
+	Units       *UnitPair   `json:"unit,omitempty"`
 }
 
 // reqPostSeries from /api/v1/series

--- a/series.go
+++ b/series.go
@@ -28,6 +28,18 @@ type Metric struct {
 	Unit   *string     `json:"unit,omitempty"`
 }
 
+// Unit represents a unit definition that we might receive when query for timeseries data.
+// A metric is characterized by 2 units as: x per y
+// One or both could be missing
+type Unit struct {
+	Family string       `json:"family"`
+	ScaleFactor float32 `json:"scale_factor"`
+	Name string         `json:"name"`
+	ShortName string    `json:"short_name"`
+	Plural string       `json:"plural"`
+	Id int              `json:"id"`
+}
+
 // Series represents a collection of data points we get when we query for timeseries data
 type Series struct {
 	Metric      *string     `json:"metric,omitempty"`
@@ -40,6 +52,7 @@ type Series struct {
 	Length      *int        `json:"length,omitempty"`
 	Scope       *string     `json:"scope,omitempty"`
 	Expression  *string     `json:"expression,omitempty"`
+	Units       *[2]*Unit   `json:"unit"`
 }
 
 // reqPostSeries from /api/v1/series


### PR DESCRIPTION
:wave: I'm pretty new to go so tell me to "go" away if this crazy talk 😸 

The query response would look like this:
```json
{
  "status": "ok",
  "res_type": "time_series",
  "series": [
    {
      "metric": "...",
      "unit": [
        {
          "family": "time",
          "scale_factor": 0.001,
          "name": "millisecond",
          "short_name": "ms",
          "plural": "milliseconds",
          "id": 10
        },
        null
      ],
      "pointlist": [...],
    }
  ]
}
```

Where the `unit` entry can either be `null` or an array of 2 "unit", where each of these units could be `nil`.

Does it make any sense?