### PR TITLE
Allow programatic set of base url

### DIFF
--- a/client.go
+++ b/client.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"net/http"
 	"time"
 )
@@ -20,7 +21,7 @@ import (
 // Client is the object that handles talking to the Datadog API. This maintains
 // state information for a particular application connection.
 type Client struct {
-	apiKey, appKey string
+	apiKey, appKey, baseUrl string
 
 	//The Http Client that is used to make requests
 	HttpClient   *http.Client
@@ -36,18 +37,29 @@ type valid struct {
 // NewClient returns a new datadog.Client which can be used to access the API
 // methods. The expected argument is the API key.
 func NewClient(apiKey, appKey string) *Client {
+	baseUrl := os.Getenv("DATADOG_HOST")
+	if baseUrl == "" {
+		baseUrl = "https://app.datadoghq.com"
+	}
+
 	return &Client{
 		apiKey:       apiKey,
 		appKey:       appKey,
+		baseUrl:      baseUrl,
 		HttpClient:   http.DefaultClient,
 		RetryTimeout: time.Duration(60 * time.Second),
 	}
 }
 
 // SetKeys changes the value of apiKey and appKey.
-func (c *Client) SetKeys(apiKey, appKey string) {
+func (c *Client) SetKeys(apiKey string, appKey string) {
 	c.apiKey = apiKey
 	c.appKey = appKey
+}
+
+// SetBaseUrl changes the value of baseUrl.
+func (c *Client) SetBaseUrl(baseUrl string) {
+	c.baseUrl = baseUrl
 }
 
 // Validate checks if the API and application keys are valid.

--- a/client.go
+++ b/client.go
@@ -52,7 +52,7 @@ func NewClient(apiKey, appKey string) *Client {
 }
 
 // SetKeys changes the value of apiKey and appKey.
-func (c *Client) SetKeys(apiKey string, appKey string) {
+func (c *Client) SetKeys(apiKey, appKey string) {
 	c.apiKey = apiKey
 	c.appKey = appKey
 }
@@ -60,6 +60,11 @@ func (c *Client) SetKeys(apiKey string, appKey string) {
 // SetBaseUrl changes the value of baseUrl.
 func (c *Client) SetBaseUrl(baseUrl string) {
 	c.baseUrl = baseUrl
+}
+
+// GetBaseUrl returns the baseUrl.
+func (c *Client) GetBaseUrl() string {
+	return c.baseUrl
 }
 
 // Validate checks if the API and application keys are valid.

--- a/integration/client_test.go
+++ b/integration/client_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,4 +32,27 @@ func TestValidAuth(t *testing.T) {
 	}
 
 	assert.Equal(t, valid, true)
+}
+
+func TestBaseUrl(t *testing.T) {
+	t.Run("Base url defaults to https://app.datadoghq.com", func(t *testing.T) {
+		assert.Empty(t, os.Getenv("DATADOG_HOST"))
+
+		client = datadog.NewClient("abc", "def")
+		assert.Equal(t, "https://app.datadoghq.com", client.GetBaseUrl())
+	})
+
+	t.Run("Base url defaults DATADOG_HOST environment variable if set", func(t *testing.T) {
+		os.Setenv("DATADOG_HOST", "https://custom.datadoghq.com")
+		defer os.Unsetenv("DATADOG_HOST")
+
+		client = datadog.NewClient("abc", "def")
+		assert.Equal(t, "https://custom.datadoghq.com", client.GetBaseUrl())
+	})
+
+	t.Run("Base url can be set through the attribute setter", func(t *testing.T) {
+		client = datadog.NewClient("abc", "def")
+		client.SetBaseUrl("https://another.datadoghq.com")
+		assert.Equal(t, "https://another.datadoghq.com", client.GetBaseUrl())
+	})
 }

--- a/request.go
+++ b/request.go
@@ -16,7 +16,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
@@ -26,11 +25,7 @@ import (
 // uriForAPI is to be called with something like "/v1/events" and it will give
 // the proper request URI to be posted to.
 func (client *Client) uriForAPI(api string) (string, error) {
-	baseUrl := os.Getenv("DATADOG_HOST")
-	if baseUrl == "" {
-		baseUrl = "https://app.datadoghq.com"
-	}
-	apiBase, err := url.Parse(baseUrl + "/api" + api)
+	apiBase, err := url.Parse(client.baseUrl + "/api" + api)
 	if err != nil {
 		return "", err
 	}

--- a/request_test.go
+++ b/request_test.go
@@ -12,6 +12,7 @@ func TestUriForApi(t *testing.T) {
 	c := Client{
 		apiKey:       "sample_api_key",
 		appKey:       "sample_app_key",
+		baseUrl:      "https://app.datadoghq.com",
 		HttpClient:   &http.Client{},
 		RetryTimeout: 1000,
 	}
@@ -32,6 +33,7 @@ func TestRedactError(t *testing.T) {
 	c := Client{
 		apiKey:       "sample_api_key",
 		appKey:       "sample_app_key",
+		baseUrl:      "https://app.datadoghq.com",
 		HttpClient:   &http.Client{},
 		RetryTimeout: 1000,
 	}

--- a/request_test.go
+++ b/request_test.go
@@ -12,20 +12,20 @@ func TestUriForApi(t *testing.T) {
 	c := Client{
 		apiKey:       "sample_api_key",
 		appKey:       "sample_app_key",
-		baseUrl:      "https://app.datadoghq.com",
+		baseUrl:      "https://base.datadoghq.com",
 		HttpClient:   &http.Client{},
 		RetryTimeout: 1000,
 	}
-	t.Run("Get Uri for api string with query string ", func(t *testing.T) {
+	t.Run("Get Uri for api string with query string", func(t *testing.T) {
 		uri, err := c.uriForAPI("/v1/events?type=critical")
 		assert.Nil(t, err)
-		assert.Equal(t, "https://app.datadoghq.com/api/v1/events?api_key=sample_api_key&application_key=sample_app_key&type=critical", uri)
+		assert.Equal(t, "https://base.datadoghq.com/api/v1/events?api_key=sample_api_key&application_key=sample_app_key&type=critical", uri)
 
 	})
 	t.Run("Get Uri for api without query string", func(t *testing.T) {
 		uri, err := c.uriForAPI("/v1/events")
 		assert.Nil(t, err)
-		assert.Equal(t, "https://app.datadoghq.com/api/v1/events?api_key=sample_api_key&application_key=sample_app_key", uri)
+		assert.Equal(t, "https://base.datadoghq.com/api/v1/events?api_key=sample_api_key&application_key=sample_app_key", uri)
 	})
 }
 
@@ -33,7 +33,7 @@ func TestRedactError(t *testing.T) {
 	c := Client{
 		apiKey:       "sample_api_key",
 		appKey:       "sample_app_key",
-		baseUrl:      "https://app.datadoghq.com",
+		baseUrl:      "https://base.datadoghq.com",
 		HttpClient:   &http.Client{},
 		RetryTimeout: 1000,
 	}


### PR DESCRIPTION
`baseUrl` to be changeable through `Client.SetBaseUrl`

Since app_key and api_key are set programatically, I don't see a reason why we wouldn't allow the same for the domain. This will allow us to handle the base url the same as we handle the keys and not in a different way.

Made the in a way where it should not break anything for existing users (except if you were dynamically changing your env variable after the client was constructed). 

Could have been simply added to the constructor but I'm not sure how to handle breaking changes in the go community or if it really made sense as most people would use the default value.

Thoughts?