### PR TITLE
Add integrations/pagerduty API Support

### DIFF
--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -7205,6 +7205,161 @@ func (i *ImageWidget) SetY(v int) {
 	i.Y = &v
 }
 
+// GetAPIToken returns the APIToken field if non-nil, zero value otherwise.
+func (i *integrationPD) GetAPIToken() string {
+	if i == nil || i.APIToken == nil {
+		return ""
+	}
+	return *i.APIToken
+}
+
+// GetOkAPIToken returns a tuple with the APIToken field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (i *integrationPD) GetAPITokenOk() (string, bool) {
+	if i == nil || i.APIToken == nil {
+		return "", false
+	}
+	return *i.APIToken, true
+}
+
+// HasAPIToken returns a boolean if a field has been set.
+func (i *integrationPD) HasAPIToken() bool {
+	if i != nil && i.APIToken != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAPIToken allocates a new i.APIToken and returns the pointer to it.
+func (i *integrationPD) SetAPIToken(v string) {
+	i.APIToken = &v
+}
+
+// GetSubdomain returns the Subdomain field if non-nil, zero value otherwise.
+func (i *integrationPD) GetSubdomain() string {
+	if i == nil || i.Subdomain == nil {
+		return ""
+	}
+	return *i.Subdomain
+}
+
+// GetOkSubdomain returns a tuple with the Subdomain field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (i *integrationPD) GetSubdomainOk() (string, bool) {
+	if i == nil || i.Subdomain == nil {
+		return "", false
+	}
+	return *i.Subdomain, true
+}
+
+// HasSubdomain returns a boolean if a field has been set.
+func (i *integrationPD) HasSubdomain() bool {
+	if i != nil && i.Subdomain != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSubdomain allocates a new i.Subdomain and returns the pointer to it.
+func (i *integrationPD) SetSubdomain(v string) {
+	i.Subdomain = &v
+}
+
+// GetAPIToken returns the APIToken field if non-nil, zero value otherwise.
+func (i *IntegrationPDRequest) GetAPIToken() string {
+	if i == nil || i.APIToken == nil {
+		return ""
+	}
+	return *i.APIToken
+}
+
+// GetOkAPIToken returns a tuple with the APIToken field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (i *IntegrationPDRequest) GetAPITokenOk() (string, bool) {
+	if i == nil || i.APIToken == nil {
+		return "", false
+	}
+	return *i.APIToken, true
+}
+
+// HasAPIToken returns a boolean if a field has been set.
+func (i *IntegrationPDRequest) HasAPIToken() bool {
+	if i != nil && i.APIToken != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAPIToken allocates a new i.APIToken and returns the pointer to it.
+func (i *IntegrationPDRequest) SetAPIToken(v string) {
+	i.APIToken = &v
+}
+
+// GetRunCheck returns the RunCheck field if non-nil, zero value otherwise.
+func (i *IntegrationPDRequest) GetRunCheck() bool {
+	if i == nil || i.RunCheck == nil {
+		return false
+	}
+	return *i.RunCheck
+}
+
+// GetOkRunCheck returns a tuple with the RunCheck field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (i *IntegrationPDRequest) GetRunCheckOk() (bool, bool) {
+	if i == nil || i.RunCheck == nil {
+		return false, false
+	}
+	return *i.RunCheck, true
+}
+
+// HasRunCheck returns a boolean if a field has been set.
+func (i *IntegrationPDRequest) HasRunCheck() bool {
+	if i != nil && i.RunCheck != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetRunCheck allocates a new i.RunCheck and returns the pointer to it.
+func (i *IntegrationPDRequest) SetRunCheck(v bool) {
+	i.RunCheck = &v
+}
+
+// GetSubdomain returns the Subdomain field if non-nil, zero value otherwise.
+func (i *IntegrationPDRequest) GetSubdomain() string {
+	if i == nil || i.Subdomain == nil {
+		return ""
+	}
+	return *i.Subdomain
+}
+
+// GetOkSubdomain returns a tuple with the Subdomain field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (i *IntegrationPDRequest) GetSubdomainOk() (string, bool) {
+	if i == nil || i.Subdomain == nil {
+		return "", false
+	}
+	return *i.Subdomain, true
+}
+
+// HasSubdomain returns a boolean if a field has been set.
+func (i *IntegrationPDRequest) HasSubdomain() bool {
+	if i != nil && i.Subdomain != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSubdomain allocates a new i.Subdomain and returns the pointer to it.
+func (i *IntegrationPDRequest) SetSubdomain(v string) {
+	i.Subdomain = &v
+}
+
 // GetHost returns the Host field if non-nil, zero value otherwise.
 func (m *Metric) GetHost() string {
 	if m == nil || m.Host == nil {
@@ -10210,6 +10365,130 @@ func (s *Series) HasStart() bool {
 // SetStart allocates a new s.Start and returns the pointer to it.
 func (s *Series) SetStart(v float64) {
 	s.Start = &v
+}
+
+// GetServiceKey returns the ServiceKey field if non-nil, zero value otherwise.
+func (s *servicePD) GetServiceKey() string {
+	if s == nil || s.ServiceKey == nil {
+		return ""
+	}
+	return *s.ServiceKey
+}
+
+// GetOkServiceKey returns a tuple with the ServiceKey field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (s *servicePD) GetServiceKeyOk() (string, bool) {
+	if s == nil || s.ServiceKey == nil {
+		return "", false
+	}
+	return *s.ServiceKey, true
+}
+
+// HasServiceKey returns a boolean if a field has been set.
+func (s *servicePD) HasServiceKey() bool {
+	if s != nil && s.ServiceKey != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetServiceKey allocates a new s.ServiceKey and returns the pointer to it.
+func (s *servicePD) SetServiceKey(v string) {
+	s.ServiceKey = &v
+}
+
+// GetServiceName returns the ServiceName field if non-nil, zero value otherwise.
+func (s *servicePD) GetServiceName() string {
+	if s == nil || s.ServiceName == nil {
+		return ""
+	}
+	return *s.ServiceName
+}
+
+// GetOkServiceName returns a tuple with the ServiceName field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (s *servicePD) GetServiceNameOk() (string, bool) {
+	if s == nil || s.ServiceName == nil {
+		return "", false
+	}
+	return *s.ServiceName, true
+}
+
+// HasServiceName returns a boolean if a field has been set.
+func (s *servicePD) HasServiceName() bool {
+	if s != nil && s.ServiceName != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetServiceName allocates a new s.ServiceName and returns the pointer to it.
+func (s *servicePD) SetServiceName(v string) {
+	s.ServiceName = &v
+}
+
+// GetServiceKey returns the ServiceKey field if non-nil, zero value otherwise.
+func (s *ServicePDRequest) GetServiceKey() string {
+	if s == nil || s.ServiceKey == nil {
+		return ""
+	}
+	return *s.ServiceKey
+}
+
+// GetOkServiceKey returns a tuple with the ServiceKey field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (s *ServicePDRequest) GetServiceKeyOk() (string, bool) {
+	if s == nil || s.ServiceKey == nil {
+		return "", false
+	}
+	return *s.ServiceKey, true
+}
+
+// HasServiceKey returns a boolean if a field has been set.
+func (s *ServicePDRequest) HasServiceKey() bool {
+	if s != nil && s.ServiceKey != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetServiceKey allocates a new s.ServiceKey and returns the pointer to it.
+func (s *ServicePDRequest) SetServiceKey(v string) {
+	s.ServiceKey = &v
+}
+
+// GetServiceName returns the ServiceName field if non-nil, zero value otherwise.
+func (s *ServicePDRequest) GetServiceName() string {
+	if s == nil || s.ServiceName == nil {
+		return ""
+	}
+	return *s.ServiceName
+}
+
+// GetOkServiceName returns a tuple with the ServiceName field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (s *ServicePDRequest) GetServiceNameOk() (string, bool) {
+	if s == nil || s.ServiceName == nil {
+		return "", false
+	}
+	return *s.ServiceName, true
+}
+
+// HasServiceName returns a boolean if a field has been set.
+func (s *ServicePDRequest) HasServiceName() bool {
+	if s != nil && s.ServiceName != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetServiceName allocates a new s.ServiceName and returns the pointer to it.
+func (s *ServicePDRequest) SetServiceName(v string) {
+	s.ServiceName = &v
 }
 
 // GetPalette returns the Palette field if non-nil, zero value otherwise.

--- a/integration/integrations_test.go
+++ b/integration/integrations_test.go
@@ -11,21 +11,21 @@ func init() {
 	client = initTest()
 }
 
-func TestIntegrationsPDCreateAndDelete(t *testing.T) {
-	expected := createTestPDIntegration(t)
-	defer cleanUpPDIntegration(t)
+func TestIntegrationPDCreateAndDelete(t *testing.T) {
+	expected := createTestIntegrationPD(t)
+	defer cleanUpIntegrationPD(t)
 
-	actual, err := client.GetPDIntegration()
+	actual, err := client.GetIntegrationPD()
 	if err != nil {
 		t.Fatalf("Retrieving a pagerduty integration failed when it shouldn't: (%s)", err)
 	}
 
-	expectedServiceNames := make([]string, len(expected.Services))
+	expectedServiceNames := make([]*string, len(expected.Services))
 	for _, service := range expected.Services {
 		expectedServiceNames = append(expectedServiceNames, service.ServiceName)
 	}
 
-	actualServiceNames := make([]string, len(actual.Services))
+	actualServiceNames := make([]*string, len(actual.Services))
 	for _, service := range actual.Services {
 		actualServiceNames = append(actualServiceNames, service.ServiceName)
 	}
@@ -33,30 +33,30 @@ func TestIntegrationsPDCreateAndDelete(t *testing.T) {
 	assert.Equal(t, expectedServiceNames, actualServiceNames)
 }
 
-func TestIntegrationsPDUpdate(t *testing.T) {
-	pdIntegration := createTestPDIntegration(t)
-	defer cleanUpPDIntegration(t)
+func TestIntegrationPDUpdate(t *testing.T) {
+	pdIntegration := createTestIntegrationPD(t)
+	defer cleanUpIntegrationPD(t)
 
-	pdIntegration.Services = append(pdIntegration.Services, datadog.PDService{
-		ServiceName: "test-pd-update",
-		ServiceKey:  "test-pd-update-key",
+	pdIntegration.Services = append(pdIntegration.Services, datadog.ServicePDRequest{
+		ServiceName: datadog.String("test-pd-update"),
+		ServiceKey:  datadog.String("test-pd-update-key"),
 	})
 
-	if err := client.UpdatePDIntegration(pdIntegration); err != nil {
+	if err := client.UpdateIntegrationPD(pdIntegration); err != nil {
 		t.Fatalf("Updating a pagerduty integration failed when it shouldn't: %s", err)
 	}
 
-	actual, err := client.GetPDIntegration()
+	actual, err := client.GetIntegrationPD()
 	if err != nil {
 		t.Fatalf("Retrieving a pagerduty integration failed when it shouldn't: %s", err)
 	}
 
-	expectedServiceNames := make([]string, len(pdIntegration.Services))
+	expectedServiceNames := make([]*string, len(pdIntegration.Services))
 	for _, service := range pdIntegration.Services {
 		expectedServiceNames = append(expectedServiceNames, service.ServiceName)
 	}
 
-	actualServiceNames := make([]string, len(actual.Services))
+	actualServiceNames := make([]*string, len(actual.Services))
 	for _, service := range actual.Services {
 		actualServiceNames = append(actualServiceNames, service.ServiceName)
 	}
@@ -64,21 +64,21 @@ func TestIntegrationsPDUpdate(t *testing.T) {
 	assert.Equal(t, expectedServiceNames, actualServiceNames)
 }
 
-func TestIntegrationsPDGet(t *testing.T) {
-	pdIntegration := createTestPDIntegration(t)
-	defer cleanUpPDIntegration(t)
+func TestIntegrationPDGet(t *testing.T) {
+	pdIntegration := createTestIntegrationPD(t)
+	defer cleanUpIntegrationPD(t)
 
-	actual, err := client.GetPDIntegration()
+	actual, err := client.GetIntegrationPD()
 	if err != nil {
 		t.Fatalf("Retrieving pdIntegration failed when it shouldn't: %s", err)
 	}
 
-	expectedServiceNames := make([]string, len(pdIntegration.Services))
+	expectedServiceNames := make([]*string, len(pdIntegration.Services))
 	for _, service := range pdIntegration.Services {
 		expectedServiceNames = append(expectedServiceNames, service.ServiceName)
 	}
 
-	actualServiceNames := make([]string, len(actual.Services))
+	actualServiceNames := make([]*string, len(actual.Services))
 	for _, service := range actual.Services {
 		actualServiceNames = append(actualServiceNames, service.ServiceName)
 	}
@@ -86,39 +86,38 @@ func TestIntegrationsPDGet(t *testing.T) {
 	assert.Equal(t, expectedServiceNames, actualServiceNames)
 }
 
-func getTestPDIntegration() *datadog.PDIntegration {
-	return &datadog.PDIntegration{
-		Services: []datadog.PDService{
+func getTestIntegrationPD() *datadog.IntegrationPDRequest {
+	return &datadog.IntegrationPDRequest{
+		Services: []datadog.ServicePDRequest{
 			{
-				ServiceName: "testPDServiceName",
-				ServiceKey:  "testPDServiceKey",
+				ServiceName: datadog.String("testPDServiceName"),
+				ServiceKey:  datadog.String("testPDServiceKey"),
 			},
 		},
-		Subdomain: "testdomain",
+		Subdomain: datadog.String("testdomain"),
 		// Datadog will actually validate this value
 		// so we're leaving it blank for tests
-		Schedules: []string{},
-		APIToken:  "abc123",
-		RunCheck:  false,
+		Schedules: []*string{},
+		APIToken:  datadog.String("abc123"),
 	}
 }
 
-func createTestPDIntegration(t *testing.T) *datadog.PDIntegration {
-	pdIntegration := getTestPDIntegration()
-	err := client.CreatePDIntegration(pdIntegration)
+func createTestIntegrationPD(t *testing.T) *datadog.IntegrationPDRequest {
+	pdIntegration := getTestIntegrationPD()
+	err := client.CreateIntegrationPD(pdIntegration)
 	if err != nil {
-		t.Fatalf("Creating a pdIntegration failed when it shouldn't: %s", err)
+		t.Fatalf("Creating a pagerduty integration failed when it shouldn't: %s", err)
 	}
 
 	return pdIntegration
 }
 
-func cleanUpPDIntegration(t *testing.T) {
-	if err := client.DeletePDIntegration(); err != nil {
+func cleanUpIntegrationPD(t *testing.T) {
+	if err := client.DeleteIntegrationPD(); err != nil {
 		t.Fatalf("Deleting the pagerduty integration failed when it shouldn't. Manual cleanup needed. (%s)", err)
 	}
 
-	pdIntegration, err := client.GetPDIntegration()
+	pdIntegration, err := client.GetIntegrationPD()
 	if pdIntegration != nil {
 		t.Fatal("PagerDuty Integration hasn't been deleted when it should have been. Manual cleanup needed.")
 	}

--- a/integration/integrations_test.go
+++ b/integration/integrations_test.go
@@ -1,0 +1,129 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zorkian/go-datadog-api"
+)
+
+func init() {
+	client = initTest()
+}
+
+func TestIntegrationsPDCreateAndDelete(t *testing.T) {
+	expected := createTestPDIntegration(t)
+	defer cleanUpPDIntegration(t)
+
+	actual, err := client.GetPDIntegration()
+	if err != nil {
+		t.Fatalf("Retrieving a pagerduty integration failed when it shouldn't: (%s)", err)
+	}
+
+	expectedServiceNames := make([]string, len(expected.Services))
+	for _, service := range expected.Services {
+		expectedServiceNames = append(expectedServiceNames, service.ServiceName)
+	}
+
+	actualServiceNames := make([]string, len(actual.Services))
+	for _, service := range actual.Services {
+		actualServiceNames = append(actualServiceNames, service.ServiceName)
+	}
+
+	assert.Equal(t, expectedServiceNames, actualServiceNames)
+}
+
+func TestIntegrationsPDUpdate(t *testing.T) {
+	pdIntegration := createTestPDIntegration(t)
+	defer cleanUpPDIntegration(t)
+
+	pdIntegration.Services = append(pdIntegration.Services, datadog.PDService{
+		ServiceName: "test-pd-update",
+		ServiceKey:  "test-pd-update-key",
+	})
+
+	if err := client.UpdatePDIntegration(pdIntegration); err != nil {
+		t.Fatalf("Updating a pagerduty integration failed when it shouldn't: %s", err)
+	}
+
+	actual, err := client.GetPDIntegration()
+	if err != nil {
+		t.Fatalf("Retrieving a pagerduty integration failed when it shouldn't: %s", err)
+	}
+
+	expectedServiceNames := make([]string, len(pdIntegration.Services))
+	for _, service := range pdIntegration.Services {
+		expectedServiceNames = append(expectedServiceNames, service.ServiceName)
+	}
+
+	actualServiceNames := make([]string, len(actual.Services))
+	for _, service := range actual.Services {
+		actualServiceNames = append(actualServiceNames, service.ServiceName)
+	}
+
+	assert.Equal(t, expectedServiceNames, actualServiceNames)
+}
+
+func TestIntegrationsPDGet(t *testing.T) {
+	pdIntegration := createTestPDIntegration(t)
+	defer cleanUpPDIntegration(t)
+
+	actual, err := client.GetPDIntegration()
+	if err != nil {
+		t.Fatalf("Retrieving pdIntegration failed when it shouldn't: %s", err)
+	}
+
+	expectedServiceNames := make([]string, len(pdIntegration.Services))
+	for _, service := range pdIntegration.Services {
+		expectedServiceNames = append(expectedServiceNames, service.ServiceName)
+	}
+
+	actualServiceNames := make([]string, len(actual.Services))
+	for _, service := range actual.Services {
+		actualServiceNames = append(actualServiceNames, service.ServiceName)
+	}
+
+	assert.Equal(t, expectedServiceNames, actualServiceNames)
+}
+
+func getTestPDIntegration() *datadog.PDIntegration {
+	return &datadog.PDIntegration{
+		Services: []datadog.PDService{
+			{
+				ServiceName: "testPDServiceName",
+				ServiceKey:  "testPDServiceKey",
+			},
+		},
+		Subdomain: "testdomain",
+		// Datadog will actually validate this value
+		// so we're leaving it blank for tests
+		Schedules: []string{},
+		APIToken:  "abc123",
+		RunCheck:  false,
+	}
+}
+
+func createTestPDIntegration(t *testing.T) *datadog.PDIntegration {
+	pdIntegration := getTestPDIntegration()
+	err := client.CreatePDIntegration(pdIntegration)
+	if err != nil {
+		t.Fatalf("Creating a pdIntegration failed when it shouldn't: %s", err)
+	}
+
+	return pdIntegration
+}
+
+func cleanUpPDIntegration(t *testing.T) {
+	if err := client.DeletePDIntegration(); err != nil {
+		t.Fatalf("Deleting the pagerduty integration failed when it shouldn't. Manual cleanup needed. (%s)", err)
+	}
+
+	pdIntegration, err := client.GetPDIntegration()
+	if pdIntegration != nil {
+		t.Fatal("PagerDuty Integration hasn't been deleted when it should have been. Manual cleanup needed.")
+	}
+
+	if err == nil {
+		t.Fatal("Fetching deleted pagerduty integration didn't lead to an error.")
+	}
+}

--- a/integration/integrations_test.go
+++ b/integration/integrations_test.go
@@ -97,7 +97,7 @@ func getTestIntegrationPD() *datadog.IntegrationPDRequest {
 		Subdomain: datadog.String("testdomain"),
 		// Datadog will actually validate this value
 		// so we're leaving it blank for tests
-		Schedules: []*string{},
+		Schedules: []string{},
 		APIToken:  datadog.String("abc123"),
 	}
 }

--- a/integrations.go
+++ b/integrations.go
@@ -8,45 +8,45 @@
 
 package datadog
 
-type reqServicePD struct {
-	ServiceName string `json:"service"`
-	ServiceKey  string `json:"key"`
+type servicePD struct {
+	ServiceName *string `json:"service"`
+	ServiceKey  *string `json:"key"`
 }
 
-type reqIntegrationPD struct {
-	Services  []reqServicePD `json:"services"`
-	Subdomain string         `json:"subdomain"`
-	Schedules []string       `json:"schedules"`
-	APIToken  string         `json:"api_token"`
+type integrationPD struct {
+	Services  []servicePD `json:"services"`
+	Subdomain *string     `json:"subdomain"`
+	Schedules []string    `json:"schedules"`
+	APIToken  *string     `json:"api_token"`
 }
 
-type ServicePD struct {
-	ServiceName string `json:"service_name"`
-	ServiceKey  string `json:"service_key"`
+type ServicePDRequest struct {
+	ServiceName *string `json:"service_name"`
+	ServiceKey  *string `json:"service_key"`
 }
 
-type IntegrationPD struct {
-	Services  []ServicePD `json:"services,omitempty"`
-	Subdomain string      `json:"subdomain,omitempty"`
-	Schedules []string    `json:"schedules,omitempty"`
-	APIToken  string      `json:"api_token,omitempty"`
-	RunCheck  bool        `json:"run_check,omitempty"`
+type IntegrationPDRequest struct {
+	Services  []ServicePDRequest `json:"services,omitempty"`
+	Subdomain *string            `json:"subdomain,omitempty"`
+	Schedules []*string          `json:"schedules,omitempty"`
+	APIToken  *string            `json:"api_token,omitempty"`
+	RunCheck  *bool              `json:"run_check,omitempty"`
 }
 
 // CreateIntegrationPD creates new Pagerduty Integrations.
-func (client *Client) CreateIntegrationPD(pdIntegration *IntegrationPD) error {
+func (client *Client) CreateIntegrationPD(pdIntegration *IntegrationPDRequest) error {
 	return client.doJsonRequest("POST", "/v1/integration/pagerduty", pdIntegration, nil)
 }
 
 // UpdateIntegrationPD updates the Pagerduty Integration.
 // This will replace the existing values with the new values
-func (client *Client) UpdateIntegrationPD(pdIntegration *IntegrationPD) error {
+func (client *Client) UpdateIntegrationPD(pdIntegration *IntegrationPDRequest) error {
 	return client.doJsonRequest("PUT", "/v1/integration/pagerduty", pdIntegration, nil)
 }
 
 // GetIntegrationPD gets all the Pagerduty Integrations from the system.
-func (client *Client) GetIntegrationPD() (*reqIntegrationPD, error) {
-	var out reqIntegrationPD
+func (client *Client) GetIntegrationPD() (*integrationPD, error) {
+	var out integrationPD
 	if err := client.doJsonRequest("GET", "/v1/integration/pagerduty", nil, &out); err != nil {
 		return nil, err
 	}

--- a/integrations.go
+++ b/integrations.go
@@ -1,0 +1,60 @@
+/*
+ * Datadog API for Go
+ *
+ * Please see the included LICENSE file for licensing information.
+ *
+ * Copyright 2013 by authors and contributors.
+ */
+
+package datadog
+
+type reqServicePD struct {
+	ServiceName string `json:"service"`
+	ServiceKey  string `json:"key"`
+}
+
+type reqIntegrationPD struct {
+	Services  []reqServicePD `json:"services"`
+	Subdomain string         `json:"subdomain"`
+	Schedules []string       `json:"schedules"`
+	APIToken  string         `json:"api_token"`
+}
+
+type ServicePD struct {
+	ServiceName string `json:"service_name"`
+	ServiceKey  string `json:"service_key"`
+}
+
+type IntegrationPD struct {
+	Services  []ServicePD `json:"services,omitempty"`
+	Subdomain string      `json:"subdomain,omitempty"`
+	Schedules []string    `json:"schedules,omitempty"`
+	APIToken  string      `json:"api_token,omitempty"`
+	RunCheck  bool        `json:"run_check,omitempty"`
+}
+
+// CreateIntegrationPD creates new Pagerduty Integrations.
+func (client *Client) CreateIntegrationPD(pdIntegration *IntegrationPD) error {
+	return client.doJsonRequest("POST", "/v1/integration/pagerduty", pdIntegration, nil)
+}
+
+// UpdateIntegrationPD updates the Pagerduty Integration.
+// This will replace the existing values with the new values
+func (client *Client) UpdateIntegrationPD(pdIntegration *IntegrationPD) error {
+	return client.doJsonRequest("PUT", "/v1/integration/pagerduty", pdIntegration, nil)
+}
+
+// GetIntegrationPD gets all the Pagerduty Integrations from the system.
+func (client *Client) GetIntegrationPD() (*reqIntegrationPD, error) {
+	var out reqIntegrationPD
+	if err := client.doJsonRequest("GET", "/v1/integration/pagerduty", nil, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+// DeleteIntegrationPD remove the PD Integration from the system.
+func (client *Client) DeleteIntegrationPD() error {
+	return client.doJsonRequest("DELETE", "/v1/integration/pagerduty", nil, nil)
+}

--- a/integrations.go
+++ b/integrations.go
@@ -28,7 +28,7 @@ type ServicePDRequest struct {
 type IntegrationPDRequest struct {
 	Services  []ServicePDRequest `json:"services,omitempty"`
 	Subdomain *string            `json:"subdomain,omitempty"`
-	Schedules []*string          `json:"schedules,omitempty"`
+	Schedules []string           `json:"schedules,omitempty"`
 	APIToken  *string            `json:"api_token,omitempty"`
 	RunCheck  *bool              `json:"run_check,omitempty"`
 }

--- a/integrations.go
+++ b/integrations.go
@@ -3,7 +3,7 @@
  *
  * Please see the included LICENSE file for licensing information.
  *
- * Copyright 2013 by authors and contributors.
+ * Copyright 2018 by authors and contributors.
  */
 
 package datadog
@@ -20,11 +20,14 @@ type integrationPD struct {
 	APIToken  *string     `json:"api_token"`
 }
 
+// ServicePDRequest defines the Services struct that is part of the IntegrationPDRequest.
 type ServicePDRequest struct {
 	ServiceName *string `json:"service_name"`
 	ServiceKey  *string `json:"service_key"`
 }
 
+// IntegrationPDRequest defines the request payload for
+// creating & updating Datadog-Pagerduty integration.
 type IntegrationPDRequest struct {
 	Services  []ServicePDRequest `json:"services,omitempty"`
 	Subdomain *string            `json:"subdomain,omitempty"`
@@ -34,12 +37,14 @@ type IntegrationPDRequest struct {
 }
 
 // CreateIntegrationPD creates new Pagerduty Integrations.
+// Use this if you want to setup the integration for the first time
+// or to add more services/schdules.
 func (client *Client) CreateIntegrationPD(pdIntegration *IntegrationPDRequest) error {
 	return client.doJsonRequest("POST", "/v1/integration/pagerduty", pdIntegration, nil)
 }
 
 // UpdateIntegrationPD updates the Pagerduty Integration.
-// This will replace the existing values with the new values
+// This will replace the existing values with the new values.
 func (client *Client) UpdateIntegrationPD(pdIntegration *IntegrationPDRequest) error {
 	return client.doJsonRequest("PUT", "/v1/integration/pagerduty", pdIntegration, nil)
 }
@@ -54,7 +59,7 @@ func (client *Client) GetIntegrationPD() (*integrationPD, error) {
 	return &out, nil
 }
 
-// DeleteIntegrationPD remove the PD Integration from the system.
+// DeleteIntegrationPD removes the PD Integration from the system.
 func (client *Client) DeleteIntegrationPD() error {
 	return client.doJsonRequest("DELETE", "/v1/integration/pagerduty", nil, nil)
 }


### PR DESCRIPTION
Datadog has recently introduced APIs to support CRUD operations for integrations(https://docs.datadoghq.com/api/?lang=bash#integrations). 

This PR adds support for CRUD operations on the Pagerduty Integration https://docs.datadoghq.com/api/?lang=bash#pagerduty. 

Things to note:
1) The request and response body does not match 1:1. For the request, the "service" object has "service_name" and "service_key" but for the response, we get "service" and "key". 
2) The integration tests  only compare the service names because 
- The service key is returned as ****
- The schedules are verified so we cannot put in fake data during creation
- The API key is returned as ****