### PR TITLE
Add integrations/slack API Support

### DIFF
--- a/comments.go
+++ b/comments.go
@@ -30,7 +30,10 @@ type reqComment struct {
 // CreateComment adds a new comment to the system.
 func (client *Client) CreateComment(handle, message string) (*Comment, error) {
 	var out reqComment
-	comment := Comment{Handle: String(handle), Message: String(message)}
+	comment := Comment{Message: String(message)}
+	if len(handle) > 0 {
+		comment.Handle = String(handle)
+	}
 	if err := client.doJsonRequest("POST", "/v1/comments", &comment, &out); err != nil {
 		return nil, err
 	}
@@ -42,7 +45,10 @@ func (client *Client) CreateComment(handle, message string) (*Comment, error) {
 func (client *Client) CreateRelatedComment(handle, message string,
 	relid int) (*Comment, error) {
 	var out reqComment
-	comment := Comment{Handle: String(handle), Message: String(message), RelatedId: Int(relid)}
+	comment := Comment{Message: String(message), RelatedId: Int(relid)}
+	if len(handle) > 0 {
+		comment.Handle = String(handle)
+	}
 	if err := client.doJsonRequest("POST", "/v1/comments", &comment, &out); err != nil {
 		return nil, err
 	}
@@ -51,7 +57,10 @@ func (client *Client) CreateRelatedComment(handle, message string,
 
 // EditComment changes the message and possibly handle of a particular comment.
 func (client *Client) EditComment(id int, handle, message string) error {
-	comment := Comment{Handle: String(handle), Message: String(message)}
+	comment := Comment{Message: String(message)}
+	if len(handle) > 0 {
+		comment.Handle = String(handle)
+	}
 	return client.doJsonRequest("PUT", fmt.Sprintf("/v1/comments/%d", id),
 		&comment, nil)
 }

--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -1470,6 +1470,99 @@ func (c *ChangeWidget) SetY(v int) {
 	c.Y = &v
 }
 
+// GetAccount returns the Account field if non-nil, zero value otherwise.
+func (c *ChannelSlackRequest) GetAccount() string {
+	if c == nil || c.Account == nil {
+		return ""
+	}
+	return *c.Account
+}
+
+// GetOkAccount returns a tuple with the Account field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (c *ChannelSlackRequest) GetAccountOk() (string, bool) {
+	if c == nil || c.Account == nil {
+		return "", false
+	}
+	return *c.Account, true
+}
+
+// HasAccount returns a boolean if a field has been set.
+func (c *ChannelSlackRequest) HasAccount() bool {
+	if c != nil && c.Account != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAccount allocates a new c.Account and returns the pointer to it.
+func (c *ChannelSlackRequest) SetAccount(v string) {
+	c.Account = &v
+}
+
+// GetChannelName returns the ChannelName field if non-nil, zero value otherwise.
+func (c *ChannelSlackRequest) GetChannelName() string {
+	if c == nil || c.ChannelName == nil {
+		return ""
+	}
+	return *c.ChannelName
+}
+
+// GetOkChannelName returns a tuple with the ChannelName field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (c *ChannelSlackRequest) GetChannelNameOk() (string, bool) {
+	if c == nil || c.ChannelName == nil {
+		return "", false
+	}
+	return *c.ChannelName, true
+}
+
+// HasChannelName returns a boolean if a field has been set.
+func (c *ChannelSlackRequest) HasChannelName() bool {
+	if c != nil && c.ChannelName != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetChannelName allocates a new c.ChannelName and returns the pointer to it.
+func (c *ChannelSlackRequest) SetChannelName(v string) {
+	c.ChannelName = &v
+}
+
+// GetTransferAllUserComments returns the TransferAllUserComments field if non-nil, zero value otherwise.
+func (c *ChannelSlackRequest) GetTransferAllUserComments() bool {
+	if c == nil || c.TransferAllUserComments == nil {
+		return false
+	}
+	return *c.TransferAllUserComments
+}
+
+// GetOkTransferAllUserComments returns a tuple with the TransferAllUserComments field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (c *ChannelSlackRequest) GetTransferAllUserCommentsOk() (bool, bool) {
+	if c == nil || c.TransferAllUserComments == nil {
+		return false, false
+	}
+	return *c.TransferAllUserComments, true
+}
+
+// HasTransferAllUserComments returns a boolean if a field has been set.
+func (c *ChannelSlackRequest) HasTransferAllUserComments() bool {
+	if c != nil && c.TransferAllUserComments != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetTransferAllUserComments allocates a new c.TransferAllUserComments and returns the pointer to it.
+func (c *ChannelSlackRequest) SetTransferAllUserComments(v bool) {
+	c.TransferAllUserComments = &v
+}
+
 // GetCheck returns the Check field if non-nil, zero value otherwise.
 func (c *Check) GetCheck() string {
 	if c == nil || c.Check == nil {
@@ -7360,6 +7453,37 @@ func (i *IntegrationPDRequest) SetSubdomain(v string) {
 	i.Subdomain = &v
 }
 
+// GetRunCheck returns the RunCheck field if non-nil, zero value otherwise.
+func (i *IntegrationSlackRequest) GetRunCheck() bool {
+	if i == nil || i.RunCheck == nil {
+		return false
+	}
+	return *i.RunCheck
+}
+
+// GetOkRunCheck returns a tuple with the RunCheck field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (i *IntegrationSlackRequest) GetRunCheckOk() (bool, bool) {
+	if i == nil || i.RunCheck == nil {
+		return false, false
+	}
+	return *i.RunCheck, true
+}
+
+// HasRunCheck returns a boolean if a field has been set.
+func (i *IntegrationSlackRequest) HasRunCheck() bool {
+	if i != nil && i.RunCheck != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetRunCheck allocates a new i.RunCheck and returns the pointer to it.
+func (i *IntegrationSlackRequest) SetRunCheck(v bool) {
+	i.RunCheck = &v
+}
+
 // GetHost returns the Host field if non-nil, zero value otherwise.
 func (m *Metric) GetHost() string {
 	if m == nil || m.Host == nil {
@@ -10396,6 +10520,68 @@ func (s *Series) HasUnits() bool {
 // SetUnits allocates a new s.Units and returns the pointer to it.
 func (s *Series) SetUnits(v UnitPair) {
 	s.Units = &v
+}
+
+// GetAccount returns the Account field if non-nil, zero value otherwise.
+func (s *ServiceHookSlackRequest) GetAccount() string {
+	if s == nil || s.Account == nil {
+		return ""
+	}
+	return *s.Account
+}
+
+// GetOkAccount returns a tuple with the Account field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (s *ServiceHookSlackRequest) GetAccountOk() (string, bool) {
+	if s == nil || s.Account == nil {
+		return "", false
+	}
+	return *s.Account, true
+}
+
+// HasAccount returns a boolean if a field has been set.
+func (s *ServiceHookSlackRequest) HasAccount() bool {
+	if s != nil && s.Account != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAccount allocates a new s.Account and returns the pointer to it.
+func (s *ServiceHookSlackRequest) SetAccount(v string) {
+	s.Account = &v
+}
+
+// GetUrl returns the Url field if non-nil, zero value otherwise.
+func (s *ServiceHookSlackRequest) GetUrl() string {
+	if s == nil || s.Url == nil {
+		return ""
+	}
+	return *s.Url
+}
+
+// GetOkUrl returns a tuple with the Url field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (s *ServiceHookSlackRequest) GetUrlOk() (string, bool) {
+	if s == nil || s.Url == nil {
+		return "", false
+	}
+	return *s.Url, true
+}
+
+// HasUrl returns a boolean if a field has been set.
+func (s *ServiceHookSlackRequest) HasUrl() bool {
+	if s != nil && s.Url != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetUrl allocates a new s.Url and returns the pointer to it.
+func (s *ServiceHookSlackRequest) SetUrl(v string) {
+	s.Url = &v
 }
 
 // GetServiceKey returns the ServiceKey field if non-nil, zero value otherwise.

--- a/integration/integrations_test.go
+++ b/integration/integrations_test.go
@@ -11,6 +11,10 @@ func init() {
 	client = initTest()
 }
 
+/*
+	PagerDuty Integration
+*/
+
 func TestIntegrationPDCreateAndDelete(t *testing.T) {
 	expected := createTestIntegrationPD(t)
 	defer cleanUpIntegrationPD(t)
@@ -124,5 +128,128 @@ func cleanUpIntegrationPD(t *testing.T) {
 
 	if err == nil {
 		t.Fatal("Fetching deleted pagerduty integration didn't lead to an error.")
+	}
+}
+
+/*
+	Slack Integration
+*/
+
+func TestIntegrationSlackCreateAndDelete(t *testing.T) {
+	expected := createTestIntegrationSlack(t)
+	defer cleanUpIntegrationSlack(t)
+
+	actual, err := client.GetIntegrationSlack()
+	if err != nil {
+		t.Fatalf("Retrieving a Slack integration failed when it shouldn't: (%s)", err)
+	}
+
+	expectedServiceHooksAccounts := make([]*string, len(expected.ServiceHooks))
+	for _, service := range expected.ServiceHooks {
+		expectedServiceHooksAccounts = append(expectedServiceHooksAccounts, service.Account)
+	}
+
+	actualServiceHooksAccounts := make([]*string, len(actual.ServiceHooks))
+	for _, service := range actual.ServiceHooks {
+		actualServiceHooksAccounts = append(actualServiceHooksAccounts, service.Account)
+	}
+
+	assert.Equal(t, expectedServiceHooksAccounts, actualServiceHooksAccounts)
+}
+
+func TestIntegrationSlackUpdate(t *testing.T) {
+	slackIntegration := createTestIntegrationSlack(t)
+	defer cleanUpIntegrationSlack(t)
+
+	slackIntegration.ServiceHooks = append(slackIntegration.ServiceHooks, datadog.ServiceHookSlackRequest{
+		Account: datadog.String("Main_Account_2"),
+		Url:     datadog.String("https://hooks.slack.com/services/2/2"),
+	})
+
+	if err := client.UpdateIntegrationSlack(slackIntegration); err != nil {
+		t.Fatalf("Updating a Slack integration failed when it shouldn't: %s", err)
+	}
+
+	actual, err := client.GetIntegrationSlack()
+	if err != nil {
+		t.Fatalf("Retrieving a Slack integration failed when it shouldn't: %s", err)
+	}
+
+	expectedServiceHooksAccounts := make([]*string, len(slackIntegration.ServiceHooks))
+	for _, service := range slackIntegration.ServiceHooks {
+		expectedServiceHooksAccounts = append(expectedServiceHooksAccounts, service.Account)
+	}
+
+	actualServiceHooksAccounts := make([]*string, len(actual.ServiceHooks))
+	for _, service := range actual.ServiceHooks {
+		actualServiceHooksAccounts = append(actualServiceHooksAccounts, service.Account)
+	}
+
+	assert.Equal(t, expectedServiceHooksAccounts, actualServiceHooksAccounts)
+}
+
+func TestIntegrationSlackGet(t *testing.T) {
+	slackIntegration := createTestIntegrationSlack(t)
+	defer cleanUpIntegrationSlack(t)
+
+	actual, err := client.GetIntegrationSlack()
+	if err != nil {
+		t.Fatalf("Retrieving Slack integration failed when it shouldn't: %s", err)
+	}
+
+	expectedServiceHooksAccounts := make([]*string, len(slackIntegration.ServiceHooks))
+	for _, service := range slackIntegration.ServiceHooks {
+		expectedServiceHooksAccounts = append(expectedServiceHooksAccounts, service.Account)
+	}
+
+	actualServiceHooksAccounts := make([]*string, len(actual.ServiceHooks))
+	for _, service := range actual.ServiceHooks {
+		actualServiceHooksAccounts = append(actualServiceHooksAccounts, service.Account)
+	}
+
+	assert.Equal(t, expectedServiceHooksAccounts, actualServiceHooksAccounts)
+}
+
+func getTestIntegrationSlack() *datadog.IntegrationSlackRequest {
+	return &datadog.IntegrationSlackRequest{
+		ServiceHooks: []datadog.ServiceHookSlackRequest{
+			{
+				Account: datadog.String("Main_Account"),
+				Url:     datadog.String("https://hooks.slack.com/services/1/1"),
+			},
+		},
+		Channels: []datadog.ChannelSlackRequest{
+			{
+				ChannelName:             datadog.String("#private"),
+				TransferAllUserComments: datadog.Bool(true),
+				Account:                 datadog.String("Main_Account"),
+			},
+		},
+	}
+}
+
+func createTestIntegrationSlack(t *testing.T) *datadog.IntegrationSlackRequest {
+	slackIntegration := getTestIntegrationSlack()
+
+	err := client.CreateIntegrationSlack(slackIntegration)
+	if err != nil {
+		t.Fatalf("Creating a Slack integration failed when it shouldn't: %s", err)
+	}
+
+	return slackIntegration
+}
+
+func cleanUpIntegrationSlack(t *testing.T) {
+	if err := client.DeleteIntegrationSlack(); err != nil {
+		t.Fatalf("Deleting the Slack integration failed when it shouldn't. Manual cleanup needed. (%s)", err)
+	}
+
+	slackIntegration, err := client.GetIntegrationSlack()
+	if slackIntegration != nil {
+		t.Fatal("Slack Integration hasn't been deleted when it should have been. Manual cleanup needed.")
+	}
+
+	if err == nil {
+		t.Fatal("Fetching deleted Slack integration didn't lead to an error.")
 	}
 }

--- a/integration/integrations_test.go
+++ b/integration/integrations_test.go
@@ -21,7 +21,7 @@ func TestIntegrationPDCreateAndDelete(t *testing.T) {
 
 	actual, err := client.GetIntegrationPD()
 	if err != nil {
-		t.Fatalf("Retrieving a pagerduty integration failed when it shouldn't: (%s)", err)
+		t.Fatalf("Retrieving a PagerDuty integration failed when it shouldn't: (%s)", err)
 	}
 
 	expectedServiceNames := make([]*string, len(expected.Services))
@@ -47,12 +47,12 @@ func TestIntegrationPDUpdate(t *testing.T) {
 	})
 
 	if err := client.UpdateIntegrationPD(pdIntegration); err != nil {
-		t.Fatalf("Updating a pagerduty integration failed when it shouldn't: %s", err)
+		t.Fatalf("Updating a PagerDuty integration failed when it shouldn't: %s", err)
 	}
 
 	actual, err := client.GetIntegrationPD()
 	if err != nil {
-		t.Fatalf("Retrieving a pagerduty integration failed when it shouldn't: %s", err)
+		t.Fatalf("Retrieving a PagerDuty integration failed when it shouldn't: %s", err)
 	}
 
 	expectedServiceNames := make([]*string, len(pdIntegration.Services))
@@ -110,7 +110,7 @@ func createTestIntegrationPD(t *testing.T) *datadog.IntegrationPDRequest {
 	pdIntegration := getTestIntegrationPD()
 	err := client.CreateIntegrationPD(pdIntegration)
 	if err != nil {
-		t.Fatalf("Creating a pagerduty integration failed when it shouldn't: %s", err)
+		t.Fatalf("Creating a PagerDuty integration failed when it shouldn't: %s", err)
 	}
 
 	return pdIntegration
@@ -118,7 +118,7 @@ func createTestIntegrationPD(t *testing.T) *datadog.IntegrationPDRequest {
 
 func cleanUpIntegrationPD(t *testing.T) {
 	if err := client.DeleteIntegrationPD(); err != nil {
-		t.Fatalf("Deleting the pagerduty integration failed when it shouldn't. Manual cleanup needed. (%s)", err)
+		t.Fatalf("Deleting the PagerDuty integration failed when it shouldn't. Manual cleanup needed. (%s)", err)
 	}
 
 	pdIntegration, err := client.GetIntegrationPD()
@@ -127,7 +127,7 @@ func cleanUpIntegrationPD(t *testing.T) {
 	}
 
 	if err == nil {
-		t.Fatal("Fetching deleted pagerduty integration didn't lead to an error.")
+		t.Fatal("Fetching deleted PagerDuty integration didn't lead to an error.")
 	}
 }
 

--- a/integrations.go
+++ b/integrations.go
@@ -1,0 +1,36 @@
+/*
+ * Datadog API for Go
+ *
+ * Please see the included LICENSE file for licensing information.
+ *
+ * Copyright 2013 by authors and contributors.
+ */
+
+package datadog
+
+type SlackChannel struct {
+	TransferAllUserComments *string `json:"transfer_all_user_comments"`
+	ChannelName *string `json:"channel_name"`
+	Account *string `json:"account"`
+}
+
+type SlackServiceHooks struct {
+	Url *string `json:"url"`
+	Account *string `json:"account"`
+}
+
+type reqSlackIntegration struct {
+	Channels []SlackChannel `json:"channels,omitempty"`
+	ServiceHooks []SlackServiceHooks`json:"channels,service_hooks"`
+}
+
+
+// Slack integration returns a list of all integrations with slack created on this account.
+func (client *Client) GetSlackIntegrations() ([]SlackChannel,[]SlackServiceHooks , error) {
+	var out reqSlackIntegration
+	if err := client.doJsonRequest("GET", "/v1/integration/slack", nil, &out); err != nil {
+		return nil, nil, err
+	}
+	return out.Channels, out.ServiceHooks, nil
+}
+

--- a/integrations.go
+++ b/integrations.go
@@ -8,6 +8,10 @@
 
 package datadog
 
+/*
+	PagerDuty Integration
+*/
+
 type servicePD struct {
 	ServiceName *string `json:"service"`
 	ServiceKey  *string `json:"key"`
@@ -38,7 +42,7 @@ type IntegrationPDRequest struct {
 
 // CreateIntegrationPD creates new Pagerduty Integrations.
 // Use this if you want to setup the integration for the first time
-// or to add more services/schdules.
+// or to add more services/schedules.
 func (client *Client) CreateIntegrationPD(pdIntegration *IntegrationPDRequest) error {
 	return client.doJsonRequest("POST", "/v1/integration/pagerduty", pdIntegration, nil)
 }
@@ -62,4 +66,57 @@ func (client *Client) GetIntegrationPD() (*integrationPD, error) {
 // DeleteIntegrationPD removes the PD Integration from the system.
 func (client *Client) DeleteIntegrationPD() error {
 	return client.doJsonRequest("DELETE", "/v1/integration/pagerduty", nil, nil)
+}
+
+/*
+	Slack Integration
+*/
+
+// ServiceHookSlackRequest defines the ServiceHooks struct that is part of the IntegrationSlackRequest.
+type ServiceHookSlackRequest struct {
+	Account *string `json:"account"`
+	Url     *string `json:"url"`
+}
+
+// ChannelSlackRequest defines the Channels struct that is part of the IntegrationSlackRequest.
+type ChannelSlackRequest struct {
+	ChannelName             *string `json:"channel_name"`
+	TransferAllUserComments *bool   `json:"transfer_all_user_comments,omitempty,string"`
+	Account                 *string `json:"account"`
+}
+
+// IntegrationSlackRequest defines the request payload for
+// creating & updating Datadog-Slack integration.
+type IntegrationSlackRequest struct {
+	ServiceHooks []ServiceHookSlackRequest `json:"service_hooks,omitempty"`
+	Channels     []ChannelSlackRequest     `json:"channels,omitempty"`
+	RunCheck     *bool                     `json:"run_check,omitempty,string"`
+}
+
+// CreateIntegrationSlack creates new Slack Integrations.
+// Use this if you want to setup the integration for the first time
+// or to add more channels.
+func (client *Client) CreateIntegrationSlack(slackIntegration *IntegrationSlackRequest) error {
+	return client.doJsonRequest("POST", "/v1/integration/slack", slackIntegration, nil)
+}
+
+// UpdateIntegrationSlack updates the Slack Integration.
+// This will replace the existing values with the new values.
+func (client *Client) UpdateIntegrationSlack(slackIntegration *IntegrationSlackRequest) error {
+	return client.doJsonRequest("PUT", "/v1/integration/slack", slackIntegration, nil)
+}
+
+// GetIntegrationSlack gets all the Slack Integrations from the system.
+func (client *Client) GetIntegrationSlack() (*IntegrationSlackRequest, error) {
+	var out IntegrationSlackRequest
+	if err := client.doJsonRequest("GET", "/v1/integration/slack", nil, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+// DeleteIntegrationSlack removes the PD Integration from the system.
+func (client *Client) DeleteIntegrationSlack() error {
+	return client.doJsonRequest("DELETE", "/v1/integration/slack", nil, nil)
 }


### PR DESCRIPTION
This PR adds support for CRUD operations for the Slack Integration https://docs.datadoghq.com/api/?lang=bash#slack.

I have followed the recently approved code structure of the PagerDuty integration (#144) . Tests have also been provided. 😄 

If you think this is a good addition to your project, please accept this PR.

Best regards,

Paulo Almeida