### PR TITLE
Add query index

### DIFF
--- a/series.go
+++ b/series.go
@@ -39,6 +39,7 @@ type Series struct {
 	Length      int         `json:"length,omitempty"`
 	Scope       string      `json:"scope,omitempty"`
 	Expression  string      `json:"expression,omitempty"`
+	QueryIndex  int         `json:"query_index,omitempty"`
 }
 
 // reqPostSeries from /api/v1/series

--- a/series.go
+++ b/series.go
@@ -22,6 +22,7 @@ type Metric struct {
 	Type   string      `json:"type,omitempty"`
 	Host   string      `json:"host,omitempty"`
 	Tags   []string    `json:"tags,omitempty"`
+	Unit   string	   `json:"unit,omitempty"`
 }
 
 // Series represents a collection of data points we get when we query for timeseries data


### PR DESCRIPTION
Adds query index to the series structure.

This is useful if you are doing a batch query and want to know
which series returned no results