### PR TITLE
Adding Integration Tests in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,25 @@
 language: go
 
 go:
-  - 1.7
-  - 1.8
-  - 1.9
-  - tip
+  - "1.7"
+  - "1.8"
+  - "1.9"
+  - "1.10.x"
+  - "tip"
 
 env:
   - "PATH=/home/travis/gopath/bin:$PATH"
-script:
-  - go get -u github.com/golang/lint/golint
-  - golint ./...
-  - make
-  - scripts/check-code-generation-ran.sh
 
 install:
   - go get -v -t .
+
+script:
+  - go get -u github.com/golang/lint/golint
+  - golint ./... | grep -v vendor/
+  - make
+  - scripts/check-code-generation-ran.sh
+  # run integration tests
+  - make testacc
 
 matrix:
     allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ script:
   - golint ./... | grep -v vendor/
   - make
   - scripts/check-code-generation-ran.sh
-  # run integration tests
-  - make testacc
+  # PR's don't have access to Travis EnvVars with DDog API Keys. Skip acceptance tests on PR.
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then make testacc; fi'
 
 matrix:
     allow_failures:


### PR DESCRIPTION
* Adds the integration tests to TravisCI (4 currently fail).
* Hopefully, this helps with #39.

You just need to add `DATADOG_API_KEY` and `DATADOG_APP_KEY` to the [TravisCI environment variables](https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings).