### PR TITLE
Fixing Some Integration Tests

### DIFF
--- a/integration/client_test.go
+++ b/integration/client_test.go
@@ -8,10 +8,6 @@ import (
 	"github.com/zorkian/go-datadog-api"
 )
 
-func init() {
-	client = initTest()
-}
-
 func TestInvalidAuth(t *testing.T) {
 	// Override the correct credentials
 	c := datadog.NewClient("INVALID", "INVALID")
@@ -38,21 +34,21 @@ func TestBaseUrl(t *testing.T) {
 	t.Run("Base url defaults to https://app.datadoghq.com", func(t *testing.T) {
 		assert.Empty(t, os.Getenv("DATADOG_HOST"))
 
-		client = datadog.NewClient("abc", "def")
-		assert.Equal(t, "https://app.datadoghq.com", client.GetBaseUrl())
+		c := datadog.NewClient("abc", "def")
+		assert.Equal(t, "https://app.datadoghq.com", c.GetBaseUrl())
 	})
 
 	t.Run("Base url defaults DATADOG_HOST environment variable if set", func(t *testing.T) {
 		os.Setenv("DATADOG_HOST", "https://custom.datadoghq.com")
 		defer os.Unsetenv("DATADOG_HOST")
 
-		client = datadog.NewClient("abc", "def")
-		assert.Equal(t, "https://custom.datadoghq.com", client.GetBaseUrl())
+		c := datadog.NewClient("abc", "def")
+		assert.Equal(t, "https://custom.datadoghq.com", c.GetBaseUrl())
 	})
 
 	t.Run("Base url can be set through the attribute setter", func(t *testing.T) {
-		client = datadog.NewClient("abc", "def")
-		client.SetBaseUrl("https://another.datadoghq.com")
-		assert.Equal(t, "https://another.datadoghq.com", client.GetBaseUrl())
+		c := datadog.NewClient("abc", "def")
+		c.SetBaseUrl("https://another.datadoghq.com")
+		assert.Equal(t, "https://another.datadoghq.com", c.GetBaseUrl())
 	})
 }

--- a/integration/dashboard_lists_test.go
+++ b/integration/dashboard_lists_test.go
@@ -7,10 +7,6 @@ import (
 	"github.com/zorkian/go-datadog-api"
 )
 
-func init() {
-	client = initTest()
-}
-
 func TestDashboardListsGet(t *testing.T) {
 	lists, err := client.GetDashboardLists()
 	if err != nil {

--- a/integration/dashboards_test.go
+++ b/integration/dashboards_test.go
@@ -7,10 +7,6 @@ import (
 	"github.com/zorkian/go-datadog-api"
 )
 
-func init() {
-	client = initTest()
-}
-
 func TestDashboardCreateAndDelete(t *testing.T) {
 	expected := getTestDashboard(createGraph)
 	// create the dashboard and compare it

--- a/integration/downtime_test.go
+++ b/integration/downtime_test.go
@@ -7,10 +7,6 @@ import (
 	"github.com/zorkian/go-datadog-api"
 )
 
-func init() {
-	client = initTest()
-}
-
 func TestDowntimeCreateAndDelete(t *testing.T) {
 	expected := getTestDowntime()
 	// create the downtime and compare it

--- a/integration/hosts_test.go
+++ b/integration/hosts_test.go
@@ -6,12 +6,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	datadog "github.com/zorkian/go-datadog-api"
+	"github.com/zorkian/go-datadog-api"
 )
-
-func init() {
-	client = initTest()
-}
 
 func TestHost_Mute(t *testing.T) {
 	muteAction := getTestMuteAction()

--- a/integration/integrations_test.go
+++ b/integration/integrations_test.go
@@ -7,10 +7,6 @@ import (
 	"github.com/zorkian/go-datadog-api"
 )
 
-func init() {
-	client = initTest()
-}
-
 /*
 	PagerDuty Integration
 */

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/zorkian/go-datadog-api"
 	"log"
 	"os"
+	"testing"
 )
 
 var (
@@ -12,7 +13,7 @@ var (
 	client *datadog.Client
 )
 
-func initTest() *datadog.Client {
+func TestMain(m *testing.M) {
 	apiKey = os.Getenv("DATADOG_API_KEY")
 	appKey = os.Getenv("DATADOG_APP_KEY")
 
@@ -20,5 +21,6 @@ func initTest() *datadog.Client {
 		log.Fatal("Please make sure to set the env variables 'DATADOG_API_KEY' and 'DATADOG_APP_KEY' before running this test")
 	}
 
-	return datadog.NewClient(apiKey, appKey)
+	client = datadog.NewClient(apiKey, appKey)
+	os.Exit(m.Run())
 }

--- a/integration/monitors_test.go
+++ b/integration/monitors_test.go
@@ -7,10 +7,6 @@ import (
 	"github.com/zorkian/go-datadog-api"
 )
 
-func init() {
-	client = initTest()
-}
-
 func TestMonitorCreateAndDelete(t *testing.T) {
 	expected := getTestMonitor()
 	// create the monitor and compare it

--- a/integration/screenboards_test.go
+++ b/integration/screenboards_test.go
@@ -5,10 +5,6 @@ import (
 	"testing"
 )
 
-func init() {
-	client = initTest()
-}
-
 func TestScreenboardCreateAndDelete(t *testing.T) {
 	expected := getTestScreenboard()
 	// create the screenboard and compare it

--- a/integration/snapshot_test.go
+++ b/integration/snapshot_test.go
@@ -15,10 +15,6 @@ func Jsonify(v interface{}) (string, error) {
 	}
 }
 
-func init() {
-	client = initTest()
-}
-
 func TestSnapshot(t *testing.T) {
 
 	end := time.Now().Unix()

--- a/integration/users_test.go
+++ b/integration/users_test.go
@@ -7,10 +7,6 @@ import (
 	"github.com/zorkian/go-datadog-api"
 )
 
-func init() {
-	client = initTest()
-}
-
 func TestUserCreateAndDelete(t *testing.T) {
 	handle := "test@example.com"
 	name := "tester"

--- a/screenboards.go
+++ b/screenboards.go
@@ -22,7 +22,7 @@ type Screenboard struct {
 	Shared            *bool              `json:"shared,omitempty"`
 	Templated         *bool              `json:"templated,omitempty"`
 	TemplateVariables []TemplateVariable `json:"template_variables,omitempty"`
-	Widgets           []Widget           `json:"widgets,omitempty"`
+	Widgets           []Widget           `json:"widgets"`
 	ReadOnly          *bool              `json:"read_only,omitempty"`
 }
 


### PR DESCRIPTION
Following #157, tests are failing. This is the first batch of fixes.

* Remove init() calls and create the shared client object in TestMain
* When junk clients are used, don't use shared client for it
* Widgets should not have `json:"omitempty"` struct field tag as per DD docs

A few remaining failures (like integrations) will need to be investigated further.