### PR TITLE
Add monitor state to monitor results

### DIFF
--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -8228,6 +8228,37 @@ func (m *Monitor) SetOptions(v Options) {
 	m.Options = &v
 }
 
+// GetOverallState returns the OverallState field if non-nil, zero value otherwise.
+func (m *Monitor) GetOverallState() string {
+	if m == nil || m.OverallState == nil {
+		return ""
+	}
+	return *m.OverallState
+}
+
+// GetOkOverallState returns a tuple with the OverallState field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (m *Monitor) GetOverallStateOk() (string, bool) {
+	if m == nil || m.OverallState == nil {
+		return "", false
+	}
+	return *m.OverallState, true
+}
+
+// HasOverallState returns a boolean if a field has been set.
+func (m *Monitor) HasOverallState() bool {
+	if m != nil && m.OverallState != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetOverallState allocates a new m.OverallState and returns the pointer to it.
+func (m *Monitor) SetOverallState(v string) {
+	m.OverallState = &v
+}
+
 // GetQuery returns the Query field if non-nil, zero value otherwise.
 func (m *Monitor) GetQuery() string {
 	if m == nil || m.Query == nil {
@@ -8257,37 +8288,6 @@ func (m *Monitor) HasQuery() bool {
 // SetQuery allocates a new m.Query and returns the pointer to it.
 func (m *Monitor) SetQuery(v string) {
 	m.Query = &v
-}
-
-// GetState returns the State field if non-nil, zero value otherwise.
-func (m *Monitor) GetState() string {
-	if m == nil || m.State == nil {
-		return ""
-	}
-	return *m.State
-}
-
-// GetOkState returns a tuple with the State field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (m *Monitor) GetStateOk() (string, bool) {
-	if m == nil || m.State == nil {
-		return "", false
-	}
-	return *m.State, true
-}
-
-// HasState returns a boolean if a field has been set.
-func (m *Monitor) HasState() bool {
-	if m != nil && m.State != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetState allocates a new m.State and returns the pointer to it.
-func (m *Monitor) SetState(v string) {
-	m.State = &v
 }
 
 // GetType returns the Type field if non-nil, zero value otherwise.

--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -8259,6 +8259,37 @@ func (m *Monitor) SetQuery(v string) {
 	m.Query = &v
 }
 
+// GetState returns the State field if non-nil, zero value otherwise.
+func (m *Monitor) GetState() string {
+	if m == nil || m.State == nil {
+		return ""
+	}
+	return *m.State
+}
+
+// GetOkState returns a tuple with the State field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (m *Monitor) GetStateOk() (string, bool) {
+	if m == nil || m.State == nil {
+		return "", false
+	}
+	return *m.State, true
+}
+
+// HasState returns a boolean if a field has been set.
+func (m *Monitor) HasState() bool {
+	if m != nil && m.State != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetState allocates a new m.State and returns the pointer to it.
+func (m *Monitor) SetState(v string) {
+	m.State = &v
+}
+
 // GetType returns the Type field if non-nil, zero value otherwise.
 func (m *Monitor) GetType() string {
 	if m == nil || m.Type == nil {

--- a/monitors.go
+++ b/monitors.go
@@ -60,15 +60,15 @@ type Options struct {
 // Monitor allows watching a metric or check that you care about,
 // notifying your team when some defined threshold is exceeded
 type Monitor struct {
-	Creator *Creator `json:"creator,omitempty"`
-	Id      *int     `json:"id,omitempty"`
-	Type    *string  `json:"type,omitempty"`
-	Query   *string  `json:"query,omitempty"`
-	Name    *string  `json:"name,omitempty"`
-	Message *string  `json:"message,omitempty"`
-	State   *string  `json:"overall_state,omitempty"`
-	Tags    []string `json:"tags"`
-	Options *Options `json:"options,omitempty"`
+	Creator      *Creator `json:"creator,omitempty"`
+	Id           *int     `json:"id,omitempty"`
+	Type         *string  `json:"type,omitempty"`
+	Query        *string  `json:"query,omitempty"`
+	Name         *string  `json:"name,omitempty"`
+	Message      *string  `json:"message,omitempty"`
+	OverallState *string  `json:"overall_state,omitempty"`
+	Tags         []string `json:"tags"`
+	Options      *Options `json:"options,omitempty"`
 }
 
 // Creator contains the creator of the monitor

--- a/monitors.go
+++ b/monitors.go
@@ -66,6 +66,7 @@ type Monitor struct {
 	Query   *string  `json:"query,omitempty"`
 	Name    *string  `json:"name,omitempty"`
 	Message *string  `json:"message,omitempty"`
+	State   *string  `json:"overall_state,omitempty"`
 	Tags    []string `json:"tags"`
 	Options *Options `json:"options,omitempty"`
 }


### PR DESCRIPTION
This allows one to use the api to trigger actions based on a monitor in
'Alert' status, as an example