### PR TITLE
Fix type issue for threshold in screenboard rule

### DIFF
--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -5005,18 +5005,18 @@ func (r *Rule) SetColor(v string) {
 }
 
 // GetThreshold returns the Threshold field if non-nil, zero value otherwise.
-func (r *Rule) GetThreshold() string {
+func (r *Rule) GetThreshold() float64 {
 	if r == nil || r.Threshold == nil {
-		return ""
+		return 0
 	}
 	return *r.Threshold
 }
 
 // GetOkThreshold returns a tuple with the Threshold field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (r *Rule) GetThresholdOk() (string, bool) {
+func (r *Rule) GetThresholdOk() (float64, bool) {
 	if r == nil || r.Threshold == nil {
-		return "", false
+		return 0, false
 	}
 	return *r.Threshold, true
 }
@@ -5031,7 +5031,7 @@ func (r *Rule) HasThreshold() bool {
 }
 
 // SetThreshold allocates a new r.Threshold and returns the pointer to it.
-func (r *Rule) SetThreshold(v string) {
+func (r *Rule) SetThreshold(v float64) {
 	r.Threshold = &v
 }
 

--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -5005,18 +5005,18 @@ func (r *Rule) SetColor(v string) {
 }
 
 // GetThreshold returns the Threshold field if non-nil, zero value otherwise.
-func (r *Rule) GetThreshold() float64 {
+func (r *Rule) GetThreshold() json.Number {
 	if r == nil || r.Threshold == nil {
-		return 0
+		return ""
 	}
 	return *r.Threshold
 }
 
 // GetOkThreshold returns a tuple with the Threshold field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (r *Rule) GetThresholdOk() (float64, bool) {
+func (r *Rule) GetThresholdOk() (json.Number, bool) {
 	if r == nil || r.Threshold == nil {
-		return 0, false
+		return "", false
 	}
 	return *r.Threshold, true
 }
@@ -5031,7 +5031,7 @@ func (r *Rule) HasThreshold() bool {
 }
 
 // SetThreshold allocates a new r.Threshold and returns the pointer to it.
-func (r *Rule) SetThreshold(v float64) {
+func (r *Rule) SetThreshold(v json.Number) {
 	r.Threshold = &v
 }
 

--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -5005,18 +5005,18 @@ func (r *Rule) SetColor(v string) {
 }
 
 // GetThreshold returns the Threshold field if non-nil, zero value otherwise.
-func (r *Rule) GetThreshold() int {
+func (r *Rule) GetThreshold() string {
 	if r == nil || r.Threshold == nil {
-		return 0
+		return ""
 	}
 	return *r.Threshold
 }
 
 // GetOkThreshold returns a tuple with the Threshold field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (r *Rule) GetThresholdOk() (int, bool) {
+func (r *Rule) GetThresholdOk() (string, bool) {
 	if r == nil || r.Threshold == nil {
-		return 0, false
+		return "", false
 	}
 	return *r.Threshold, true
 }
@@ -5031,7 +5031,7 @@ func (r *Rule) HasThreshold() bool {
 }
 
 // SetThreshold allocates a new r.Threshold and returns the pointer to it.
-func (r *Rule) SetThreshold(v int) {
+func (r *Rule) SetThreshold(v string) {
 	r.Threshold = &v
 }
 

--- a/integration/screen_widgets_test.go
+++ b/integration/screen_widgets_test.go
@@ -351,6 +351,7 @@ func TestWidgets(t *testing.T) {
 			},
 		},
 		{
+			// Widget is undocumented, subject to breaking API changes, and without customer support
 			Type:   datadog.String("uptime"),
 			X:      datadog.Int(1),
 			Y:      datadog.Int(1),

--- a/screen_widgets.go
+++ b/screen_widgets.go
@@ -191,7 +191,7 @@ type Params struct {
 }
 
 type Rule struct {
-	Threshold *int    `json:"threshold,omitempty"`
+	Threshold *string `json:"threshold,omitempty"`
 	Timeframe *string `json:"timeframe,omitempty"`
 	Color     *string `json:"color,omitempty"`
 }

--- a/screen_widgets.go
+++ b/screen_widgets.go
@@ -191,9 +191,9 @@ type Params struct {
 }
 
 type Rule struct {
-	Threshold *string `json:"threshold,omitempty"`
-	Timeframe *string `json:"timeframe,omitempty"`
-	Color     *string `json:"color,omitempty"`
+	Threshold *float64 `json:"threshold,omitempty"`
+	Timeframe *string  `json:"timeframe,omitempty"`
+	Color     *string  `json:"color,omitempty"`
 }
 
 type ScreenboardMonitor struct {

--- a/screen_widgets.go
+++ b/screen_widgets.go
@@ -1,5 +1,7 @@
 package datadog
 
+import "encoding/json"
+
 type TileDef struct {
 	Events     []TileDefEvent   `json:"events,omitempty"`
 	Markers    []TileDefMarker  `json:"markers,omitempty"`
@@ -192,9 +194,9 @@ type Params struct {
 }
 
 type Rule struct {
-	Threshold *float64 `json:"threshold,omitempty"`
-	Timeframe *string  `json:"timeframe,omitempty"`
-	Color     *string  `json:"color,omitempty"`
+	Threshold *json.Number `json:"threshold,omitempty"`
+	Timeframe *string      `json:"timeframe,omitempty"`
+	Color     *string      `json:"color,omitempty"`
 }
 
 type ScreenboardMonitor struct {

--- a/screen_widgets.go
+++ b/screen_widgets.go
@@ -178,6 +178,7 @@ type Widget struct {
 	Logset  *string `json:"logset,omitempty"`
 
 	// For Uptime
+	// Widget is undocumented, subject to breaking API changes, and without customer support
 	Timeframes []*string           `json:"timeframes,omitempty"`
 	Rules      map[string]*Rule    `json:"rules,omitempty"`
 	Monitor    *ScreenboardMonitor `json:"monitor,omitempty"`


### PR DESCRIPTION
Because of a type issue, we could not submit thresholds such as `99.9` for rules in the uptime widget.

This PR fixes that.