### PR TITLE
Introduce NodeType field for dashboard hostmap widgets.

### DIFF
--- a/dashboards.go
+++ b/dashboards.go
@@ -127,10 +127,12 @@ type GraphDefinition struct {
 	// For hostname type graphs
 	Style *Style `json:"Style,omitempty"`
 
+	// For hostmaps
 	Groups                []string `json:"group,omitempty"`
 	IncludeNoMetricHosts  *bool    `json:"noMetricHosts,omitempty"`
 	Scopes                []string `json:"scope,omitempty"`
 	IncludeUngroupedHosts *bool    `json:"noGroupHosts,omitempty"`
+	NodeType              *string  `json:"nodeType,omitempty"`
 }
 
 // Graph represents a graph that might exist on a dashboard.

--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -2462,6 +2462,37 @@ func (g *GraphDefinition) SetIncludeUngroupedHosts(v bool) {
 	g.IncludeUngroupedHosts = &v
 }
 
+// GetNodeType returns the NodeType field if non-nil, zero value otherwise.
+func (g *GraphDefinition) GetNodeType() string {
+	if g == nil || g.NodeType == nil {
+		return ""
+	}
+	return *g.NodeType
+}
+
+// GetOkNodeType returns a tuple with the NodeType field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (g *GraphDefinition) GetNodeTypeOk() (string, bool) {
+	if g == nil || g.NodeType == nil {
+		return "", false
+	}
+	return *g.NodeType, true
+}
+
+// HasNodeType returns a boolean if a field has been set.
+func (g *GraphDefinition) HasNodeType() bool {
+	if g != nil && g.NodeType != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetNodeType allocates a new g.NodeType and returns the pointer to it.
+func (g *GraphDefinition) SetNodeType(v string) {
+	g.NodeType = &v
+}
+
 // GetPrecision returns the Precision field if non-nil, zero value otherwise.
 func (g *GraphDefinition) GetPrecision() string {
 	if g == nil || g.Precision == nil {


### PR DESCRIPTION
A hostmap widget can have nodetype with either `host` (default) or `container`.

![image](https://user-images.githubusercontent.com/373323/46612623-638f0500-cb11-11e8-997a-f0b98294a3dd.png)

Example exported hostmap widgets:

```
{
  "Style": {
    "palette": "green_to_orange"
  },
  "autoscale": false,
  "text_align": "",
  "precision": "",
  "noMetricHosts": false,
  "custom_unit": "",
  "viz": "hostmap",
  "scope": null,
  "requests": [
    {
      "q": "max:system.load.1{*} by {host}",
      "type": "fill"
    }
  ],
  "group": [],
  "noGroupHosts": false,
  "status": "done",
  "style": {
    "palette": "green_to_orange",
    "paletteFlip": false,
    "fillMin": null,
    "fillMax": null
  },
  "nodeType": "host",
  "notes": null
}
```

```
{
  "Style": {
    "palette": "green_to_orange"
  },
  "autoscale": false,
  "text_align": "",
  "precision": "",
  "noMetricHosts": false,
  "custom_unit": "",
  "viz": "hostmap",
  "scope": null,
  "requests": [
    {
      "q": "max:process.stat.container.io.wbps{*} by {host}",
      "type": "fill"
    }
  ],
  "group": [],
  "noGroupHosts": false,
  "status": "done",
  "style": {
    "palette": "green_to_orange",
    "paletteFlip": false,
    "fillMin": null,
    "fillMax": null
  },
  "nodeType": "container",
  "notes": null
}
```