### PR TITLE
Change GraphDefinition.Precision type

### DIFF
--- a/dashboards.go
+++ b/dashboards.go
@@ -121,10 +121,10 @@ type GraphDefinition struct {
 	Yaxis Yaxis `json:"yaxis,omitempty"`
 
 	// For query value type graphs
-	Autoscale  *bool   `json:"autoscale,omitempty"`
-	TextAlign  *string `json:"text_align,omitempty"`
-	Precision  *string `json:"precision,omitempty"`
-	CustomUnit *string `json:"custom_unit,omitempty"`
+	Autoscale  *bool        `json:"autoscale,omitempty"`
+	TextAlign  *string      `json:"text_align,omitempty"`
+	Precision  *json.Number `json:"precision,omitempty"`
+	CustomUnit *string      `json:"custom_unit,omitempty"`
 
 	// For hostmaps
 	Style                 *Style   `json:"style,omitempty"`

--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -2494,7 +2494,7 @@ func (g *GraphDefinition) SetNodeType(v string) {
 }
 
 // GetPrecision returns the Precision field if non-nil, zero value otherwise.
-func (g *GraphDefinition) GetPrecision() string {
+func (g *GraphDefinition) GetPrecision() json.Number {
 	if g == nil || g.Precision == nil {
 		return ""
 	}
@@ -2503,7 +2503,7 @@ func (g *GraphDefinition) GetPrecision() string {
 
 // GetPrecisionOk returns a tuple with the Precision field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (g *GraphDefinition) GetPrecisionOk() (string, bool) {
+func (g *GraphDefinition) GetPrecisionOk() (json.Number, bool) {
 	if g == nil || g.Precision == nil {
 		return "", false
 	}
@@ -2520,7 +2520,7 @@ func (g *GraphDefinition) HasPrecision() bool {
 }
 
 // SetPrecision allocates a new g.Precision and returns the pointer to it.
-func (g *GraphDefinition) SetPrecision(v string) {
+func (g *GraphDefinition) SetPrecision(v json.Number) {
 	g.Precision = &v
 }
 
@@ -6710,7 +6710,7 @@ func (t *TileDef) SetNoMetricHosts(v bool) {
 }
 
 // GetPrecision returns the Precision field if non-nil, zero value otherwise.
-func (t *TileDef) GetPrecision() string {
+func (t *TileDef) GetPrecision() json.Number {
 	if t == nil || t.Precision == nil {
 		return ""
 	}
@@ -6719,7 +6719,7 @@ func (t *TileDef) GetPrecision() string {
 
 // GetPrecisionOk returns a tuple with the Precision field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (t *TileDef) GetPrecisionOk() (string, bool) {
+func (t *TileDef) GetPrecisionOk() (json.Number, bool) {
 	if t == nil || t.Precision == nil {
 		return "", false
 	}
@@ -6736,7 +6736,7 @@ func (t *TileDef) HasPrecision() bool {
 }
 
 // SetPrecision allocates a new t.Precision and returns the pointer to it.
-func (t *TileDef) SetPrecision(v string) {
+func (t *TileDef) SetPrecision(v json.Number) {
 	t.Precision = &v
 }
 

--- a/integration/screen_widgets_test.go
+++ b/integration/screen_widgets_test.go
@@ -91,7 +91,7 @@ func TestWidgets(t *testing.T) {
 				}},
 				CustomUnit: datadog.String("%"),
 				Autoscale:  datadog.Bool(false),
-				Precision:  datadog.String("6"),
+				Precision:  datadog.JsonNumber("6"),
 				TextAlign:  datadog.String("right"),
 			},
 		},
@@ -241,7 +241,7 @@ func TestWidgets(t *testing.T) {
 			AlertID:    datadog.Int(123456),
 			TextSize:   datadog.String("fill_height"),
 			TextAlign:  datadog.String("right"),
-			Precision:  datadog.String("*"),
+			Precision:  datadog.JsonNumber("*"),
 			Unit:       datadog.String("b"),
 		},
 		{

--- a/screen_widgets.go
+++ b/screen_widgets.go
@@ -9,7 +9,7 @@ type TileDef struct {
 	Viz        *string          `json:"viz,omitempty"`
 	CustomUnit *string          `json:"custom_unit,omitempty"`
 	Autoscale  *bool            `json:"autoscale,omitempty"`
-	Precision  *string          `json:"precision,omitempty"`
+	Precision  *json.Number     `json:"precision,omitempty"`
 	TextAlign  *string          `json:"text_align,omitempty"`
 
 	// For hostmap


### PR DESCRIPTION
* Datadog's API will accept / return the following types for precision
(query value widget on timeboards / screenboards): int (e.g., 4), string
with integer inside (e.g., "4"), or the specific string "*" (meaning
full precision). This commit adds support for the integer case.