### PR TITLE
install golint from golang.org/x/lint/golint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
 
 script:
   - scripts/check-fmt.sh
-  - go get -u github.com/golang/lint/golint
+  - go get -u golang.org/x/lint/golint
   - golint ./... | grep -v vendor/
   - make
   - scripts/check-code-generation-ran.sh


### PR DESCRIPTION
Current Travis build show: 

```
$ go get -u github.com/golang/lint/golint
package github.com/golang/lint/golint: code in directory /home/travis/gopath/src/github.com/golang/lint/golint expects import "golang.org/x/lint/golint"
```