### PR TITLE
Add missing dashboard fields

### DIFF
--- a/dashboards.go
+++ b/dashboards.go
@@ -162,10 +162,27 @@ type Dashboard struct {
 // DashboardLite represents a user created dashboard. This is the mini
 // struct when we load the summaries.
 type DashboardLite struct {
-	Id          *int    `json:"id,string,omitempty"` // TODO: Remove ',string'.
-	Resource    *string `json:"resource,omitempty"`
-	Description *string `json:"description,omitempty"`
-	Title       *string `json:"title,omitempty"`
+	Id          *int       `json:"id,string,omitempty"` // TODO: Remove ',string'.
+	Resource    *string    `json:"resource,omitempty"`
+	Description *string    `json:"description,omitempty"`
+	Title       *string    `json:"title,omitempty"`
+	ReadOnly    *bool      `json:"read_only,omitempty"`
+	Created     *string    `json:"created,omitempty"`
+	Modified    *string    `json:"modified,omitempty"`
+	CreatedBy   *CreatedBy `json:"created_by,omitempty"`
+}
+
+// CreatedBy represents a field from DashboardLite.
+type CreatedBy struct {
+	Disabled   *bool   `json:"disabled,omitempty"`
+	Handle     *string `json:"handle,omitempty"`
+	Name       *string `json:"name,omitempty"`
+	IsAdmin    *bool   `json:"is_admin,omitempty"`
+	Role       *string `json:"role,omitempty"`
+	AccessRole *string `json:"access_role,omitempty"`
+	Verified   *bool   `json:"verified,omitempty"`
+	Email      *string `json:"email,omitempty"`
+	Icon       *string `json:"icon,omitempty"`
 }
 
 // reqGetDashboards from /api/v1/dash

--- a/dashboards_test.go
+++ b/dashboards_test.go
@@ -2,6 +2,9 @@ package datadog
 
 import (
 	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -74,4 +77,155 @@ func (suite *YAxisTestSuite) TestYAxisJSONUnmarshalAutoMinMax() {
 
 func TestYAxisTestSuite(t *testing.T) {
 	suite.Run(t, new(YAxisTestSuite))
+}
+
+func TestDashboardGetters(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response, err := ioutil.ReadFile("./tests/fixtures/dashboards_response.json")
+		if err != nil {
+			t.Fatal(err)
+		}
+		w.Write(response)
+	}))
+	defer ts.Close()
+
+	datadogClient := Client{
+		baseUrl:    ts.URL,
+		HttpClient: http.DefaultClient,
+	}
+
+	dashboards, err := datadogClient.GetDashboards()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(dashboards) != 2 {
+		t.Fatalf("expect response with 2 dashboards. Got %d", len(dashboards))
+	}
+
+	d1 := dashboards[0]
+
+	expectedID := 123
+	if id := d1.GetId(); id != expectedID {
+		t.Fatalf("expect ID %d. Got %d", expectedID, id)
+	}
+
+	expectedTitle := "Dashboard 1"
+	if title := d1.GetTitle(); title != expectedTitle {
+		t.Fatalf("expect title %s. Got %s", expectedTitle, title)
+	}
+
+	expectedDescription := "created by user1"
+	if description := d1.GetDescription(); description != expectedDescription {
+		t.Fatalf("expect description %s. Got %s", expectedDescription, description)
+	}
+
+	expectedCreateTime := "2018-10-05T12:32:01.000000+00:00"
+	createTime, ok := d1.GetCreatedOk()
+	if !ok {
+		t.Fatalf("expect to have a created field")
+	}
+
+	if createTime != expectedCreateTime {
+		t.Fatalf("expect create time %s. Got %s", expectedCreateTime, createTime)
+	}
+
+	expectedReadOnly := false
+	readOnly, ok := d1.GetReadOnlyOk()
+	if !ok {
+		t.Fatalf("expect to have a read_only field")
+	}
+
+	if readOnly != expectedReadOnly {
+		t.Fatalf("expect read_only %v. Got %v", expectedReadOnly, readOnly)
+	}
+
+	expectedModified := "2018-09-11T06:38:09.000000+00:00"
+	modified, ok := d1.GetModifiedOk()
+	if !ok {
+		t.Fatalf("expect to have a modified field")
+	}
+
+	if modified != expectedModified {
+		t.Fatalf("expect modified %s. Got %s", expectedModified, modified)
+	}
+
+	createdBy, ok := d1.GetCreatedByOk()
+	if !ok {
+		t.Fatal("expect created_by field to exist")
+	}
+
+	validateCreatedBy(t, &createdBy)
+}
+
+func validateCreatedBy(t *testing.T, cb *CreatedBy) {
+	expectedAccessRole := "adm"
+	accessRole, ok := cb.GetAccessRoleOk()
+	if !ok {
+		t.Fatal("expect to have access_role field")
+	}
+
+	if accessRole != expectedAccessRole {
+		t.Fatalf("expect access_role %s. Got %s", expectedAccessRole, accessRole)
+	}
+
+	expectedDisabled := true
+	disabled, ok := cb.GetDisabledOk()
+	if !ok {
+		t.Fatal("expect to have disabled field")
+	}
+
+	if disabled != expectedDisabled {
+		t.Fatalf("expect disabled %v. Got %v", expectedDisabled, disabled)
+	}
+
+	expectedEmail := "john.doe@company.com"
+	email, ok := cb.GetEmailOk()
+	if !ok {
+		t.Fatal("expect to have email field")
+	}
+
+	if email != expectedEmail {
+		t.Fatalf("expect email %s. Got %s", expectedEmail, email)
+	}
+
+	expectedHandle := "john.doe@company.com"
+	handle, ok := cb.GetHandleOk()
+	if !ok {
+		t.Fatal("expect to have handle field")
+	}
+
+	if handle != expectedHandle {
+		t.Fatalf("expect handle %s. Got %s", expectedHandle, handle)
+	}
+
+	expectedIcon := "https://pics.site.com/123.jpg"
+	icon, ok := cb.GetIconOk()
+	if !ok {
+		t.Fatal("expect to have icon field")
+	}
+
+	if icon != expectedIcon {
+		t.Fatalf("expect icon %s. Got %s", expectedIcon, icon)
+	}
+
+	expectedName := "John Doe"
+	name, ok := cb.GetNameOk()
+	if !ok {
+		t.Fatal("expect to have name field")
+	}
+
+	if name != expectedName {
+		t.Fatalf("expect name %s. Got %s", expectedName, name)
+	}
+
+	expectedVerified := true
+	verified, ok := cb.GetVerifiedOk()
+	if !ok {
+		t.Fatal("expect to have verified field")
+	}
+
+	if verified != expectedVerified {
+		t.Fatalf("expect verify %v. Got %v", expectedVerified, verified)
+	}
 }

--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -881,6 +881,285 @@ func (c *ConditionalFormat) SetValue(v string) {
 	c.Value = &v
 }
 
+// GetAccessRole returns the AccessRole field if non-nil, zero value otherwise.
+func (c *CreatedBy) GetAccessRole() string {
+	if c == nil || c.AccessRole == nil {
+		return ""
+	}
+	return *c.AccessRole
+}
+
+// GetAccessRoleOk returns a tuple with the AccessRole field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (c *CreatedBy) GetAccessRoleOk() (string, bool) {
+	if c == nil || c.AccessRole == nil {
+		return "", false
+	}
+	return *c.AccessRole, true
+}
+
+// HasAccessRole returns a boolean if a field has been set.
+func (c *CreatedBy) HasAccessRole() bool {
+	if c != nil && c.AccessRole != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAccessRole allocates a new c.AccessRole and returns the pointer to it.
+func (c *CreatedBy) SetAccessRole(v string) {
+	c.AccessRole = &v
+}
+
+// GetDisabled returns the Disabled field if non-nil, zero value otherwise.
+func (c *CreatedBy) GetDisabled() bool {
+	if c == nil || c.Disabled == nil {
+		return false
+	}
+	return *c.Disabled
+}
+
+// GetDisabledOk returns a tuple with the Disabled field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (c *CreatedBy) GetDisabledOk() (bool, bool) {
+	if c == nil || c.Disabled == nil {
+		return false, false
+	}
+	return *c.Disabled, true
+}
+
+// HasDisabled returns a boolean if a field has been set.
+func (c *CreatedBy) HasDisabled() bool {
+	if c != nil && c.Disabled != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetDisabled allocates a new c.Disabled and returns the pointer to it.
+func (c *CreatedBy) SetDisabled(v bool) {
+	c.Disabled = &v
+}
+
+// GetEmail returns the Email field if non-nil, zero value otherwise.
+func (c *CreatedBy) GetEmail() string {
+	if c == nil || c.Email == nil {
+		return ""
+	}
+	return *c.Email
+}
+
+// GetEmailOk returns a tuple with the Email field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (c *CreatedBy) GetEmailOk() (string, bool) {
+	if c == nil || c.Email == nil {
+		return "", false
+	}
+	return *c.Email, true
+}
+
+// HasEmail returns a boolean if a field has been set.
+func (c *CreatedBy) HasEmail() bool {
+	if c != nil && c.Email != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetEmail allocates a new c.Email and returns the pointer to it.
+func (c *CreatedBy) SetEmail(v string) {
+	c.Email = &v
+}
+
+// GetHandle returns the Handle field if non-nil, zero value otherwise.
+func (c *CreatedBy) GetHandle() string {
+	if c == nil || c.Handle == nil {
+		return ""
+	}
+	return *c.Handle
+}
+
+// GetHandleOk returns a tuple with the Handle field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (c *CreatedBy) GetHandleOk() (string, bool) {
+	if c == nil || c.Handle == nil {
+		return "", false
+	}
+	return *c.Handle, true
+}
+
+// HasHandle returns a boolean if a field has been set.
+func (c *CreatedBy) HasHandle() bool {
+	if c != nil && c.Handle != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetHandle allocates a new c.Handle and returns the pointer to it.
+func (c *CreatedBy) SetHandle(v string) {
+	c.Handle = &v
+}
+
+// GetIcon returns the Icon field if non-nil, zero value otherwise.
+func (c *CreatedBy) GetIcon() string {
+	if c == nil || c.Icon == nil {
+		return ""
+	}
+	return *c.Icon
+}
+
+// GetIconOk returns a tuple with the Icon field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (c *CreatedBy) GetIconOk() (string, bool) {
+	if c == nil || c.Icon == nil {
+		return "", false
+	}
+	return *c.Icon, true
+}
+
+// HasIcon returns a boolean if a field has been set.
+func (c *CreatedBy) HasIcon() bool {
+	if c != nil && c.Icon != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetIcon allocates a new c.Icon and returns the pointer to it.
+func (c *CreatedBy) SetIcon(v string) {
+	c.Icon = &v
+}
+
+// GetIsAdmin returns the IsAdmin field if non-nil, zero value otherwise.
+func (c *CreatedBy) GetIsAdmin() bool {
+	if c == nil || c.IsAdmin == nil {
+		return false
+	}
+	return *c.IsAdmin
+}
+
+// GetIsAdminOk returns a tuple with the IsAdmin field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (c *CreatedBy) GetIsAdminOk() (bool, bool) {
+	if c == nil || c.IsAdmin == nil {
+		return false, false
+	}
+	return *c.IsAdmin, true
+}
+
+// HasIsAdmin returns a boolean if a field has been set.
+func (c *CreatedBy) HasIsAdmin() bool {
+	if c != nil && c.IsAdmin != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetIsAdmin allocates a new c.IsAdmin and returns the pointer to it.
+func (c *CreatedBy) SetIsAdmin(v bool) {
+	c.IsAdmin = &v
+}
+
+// GetName returns the Name field if non-nil, zero value otherwise.
+func (c *CreatedBy) GetName() string {
+	if c == nil || c.Name == nil {
+		return ""
+	}
+	return *c.Name
+}
+
+// GetNameOk returns a tuple with the Name field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (c *CreatedBy) GetNameOk() (string, bool) {
+	if c == nil || c.Name == nil {
+		return "", false
+	}
+	return *c.Name, true
+}
+
+// HasName returns a boolean if a field has been set.
+func (c *CreatedBy) HasName() bool {
+	if c != nil && c.Name != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetName allocates a new c.Name and returns the pointer to it.
+func (c *CreatedBy) SetName(v string) {
+	c.Name = &v
+}
+
+// GetRole returns the Role field if non-nil, zero value otherwise.
+func (c *CreatedBy) GetRole() string {
+	if c == nil || c.Role == nil {
+		return ""
+	}
+	return *c.Role
+}
+
+// GetRoleOk returns a tuple with the Role field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (c *CreatedBy) GetRoleOk() (string, bool) {
+	if c == nil || c.Role == nil {
+		return "", false
+	}
+	return *c.Role, true
+}
+
+// HasRole returns a boolean if a field has been set.
+func (c *CreatedBy) HasRole() bool {
+	if c != nil && c.Role != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetRole allocates a new c.Role and returns the pointer to it.
+func (c *CreatedBy) SetRole(v string) {
+	c.Role = &v
+}
+
+// GetVerified returns the Verified field if non-nil, zero value otherwise.
+func (c *CreatedBy) GetVerified() bool {
+	if c == nil || c.Verified == nil {
+		return false
+	}
+	return *c.Verified
+}
+
+// GetVerifiedOk returns a tuple with the Verified field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (c *CreatedBy) GetVerifiedOk() (bool, bool) {
+	if c == nil || c.Verified == nil {
+		return false, false
+	}
+	return *c.Verified, true
+}
+
+// HasVerified returns a boolean if a field has been set.
+func (c *CreatedBy) HasVerified() bool {
+	if c != nil && c.Verified != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetVerified allocates a new c.Verified and returns the pointer to it.
+func (c *CreatedBy) SetVerified(v bool) {
+	c.Verified = &v
+}
+
 // GetEmail returns the Email field if non-nil, zero value otherwise.
 func (c *Creator) GetEmail() string {
 	if c == nil || c.Email == nil {
@@ -1501,6 +1780,68 @@ func (d *DashboardListItem) SetType(v string) {
 	d.Type = &v
 }
 
+// GetCreated returns the Created field if non-nil, zero value otherwise.
+func (d *DashboardLite) GetCreated() string {
+	if d == nil || d.Created == nil {
+		return ""
+	}
+	return *d.Created
+}
+
+// GetCreatedOk returns a tuple with the Created field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (d *DashboardLite) GetCreatedOk() (string, bool) {
+	if d == nil || d.Created == nil {
+		return "", false
+	}
+	return *d.Created, true
+}
+
+// HasCreated returns a boolean if a field has been set.
+func (d *DashboardLite) HasCreated() bool {
+	if d != nil && d.Created != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCreated allocates a new d.Created and returns the pointer to it.
+func (d *DashboardLite) SetCreated(v string) {
+	d.Created = &v
+}
+
+// GetCreatedBy returns the CreatedBy field if non-nil, zero value otherwise.
+func (d *DashboardLite) GetCreatedBy() CreatedBy {
+	if d == nil || d.CreatedBy == nil {
+		return CreatedBy{}
+	}
+	return *d.CreatedBy
+}
+
+// GetCreatedByOk returns a tuple with the CreatedBy field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (d *DashboardLite) GetCreatedByOk() (CreatedBy, bool) {
+	if d == nil || d.CreatedBy == nil {
+		return CreatedBy{}, false
+	}
+	return *d.CreatedBy, true
+}
+
+// HasCreatedBy returns a boolean if a field has been set.
+func (d *DashboardLite) HasCreatedBy() bool {
+	if d != nil && d.CreatedBy != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCreatedBy allocates a new d.CreatedBy and returns the pointer to it.
+func (d *DashboardLite) SetCreatedBy(v CreatedBy) {
+	d.CreatedBy = &v
+}
+
 // GetDescription returns the Description field if non-nil, zero value otherwise.
 func (d *DashboardLite) GetDescription() string {
 	if d == nil || d.Description == nil {
@@ -1561,6 +1902,68 @@ func (d *DashboardLite) HasId() bool {
 // SetId allocates a new d.Id and returns the pointer to it.
 func (d *DashboardLite) SetId(v int) {
 	d.Id = &v
+}
+
+// GetModified returns the Modified field if non-nil, zero value otherwise.
+func (d *DashboardLite) GetModified() string {
+	if d == nil || d.Modified == nil {
+		return ""
+	}
+	return *d.Modified
+}
+
+// GetModifiedOk returns a tuple with the Modified field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (d *DashboardLite) GetModifiedOk() (string, bool) {
+	if d == nil || d.Modified == nil {
+		return "", false
+	}
+	return *d.Modified, true
+}
+
+// HasModified returns a boolean if a field has been set.
+func (d *DashboardLite) HasModified() bool {
+	if d != nil && d.Modified != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetModified allocates a new d.Modified and returns the pointer to it.
+func (d *DashboardLite) SetModified(v string) {
+	d.Modified = &v
+}
+
+// GetReadOnly returns the ReadOnly field if non-nil, zero value otherwise.
+func (d *DashboardLite) GetReadOnly() bool {
+	if d == nil || d.ReadOnly == nil {
+		return false
+	}
+	return *d.ReadOnly
+}
+
+// GetReadOnlyOk returns a tuple with the ReadOnly field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (d *DashboardLite) GetReadOnlyOk() (bool, bool) {
+	if d == nil || d.ReadOnly == nil {
+		return false, false
+	}
+	return *d.ReadOnly, true
+}
+
+// HasReadOnly returns a boolean if a field has been set.
+func (d *DashboardLite) HasReadOnly() bool {
+	if d != nil && d.ReadOnly != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetReadOnly allocates a new d.ReadOnly and returns the pointer to it.
+func (d *DashboardLite) SetReadOnly(v bool) {
+	d.ReadOnly = &v
 }
 
 // GetResource returns the Resource field if non-nil, zero value otherwise.

--- a/tests/fixtures/dashboards_response.json
+++ b/tests/fixtures/dashboards_response.json
@@ -1,0 +1,44 @@
+{
+  "dashes": [
+    {
+      "read_only": false,
+      "resource": "/api/v1/dash/123",
+      "description": "created by user1",
+      "title": "Dashboard 1",
+      "created": "2018-10-05T12:32:01.000000+00:00",
+      "id": "123",
+      "created_by": {
+        "disabled": true,
+        "handle": "john.doe@company.com",
+        "name": "John Doe",
+        "is_admin": true,
+        "role": null,
+        "access_role": "adm",
+        "verified": true,
+        "email": "john.doe@company.com",
+        "icon": "https://pics.site.com/123.jpg"
+      },
+      "modified": "2018-09-11T06:38:09.000000+00:00"
+    },
+    {
+      "read_only": false,
+      "resource": "/api/v1/dash/1234",
+      "description": "created by user2",
+      "title": "Dashboard 2",
+      "created": "2018-01-01T00:00:00.000000+00:00",
+      "id": "1234",
+      "created_by": {
+        "disabled": false,
+        "handle": "jane.doe@company.com",
+        "name": "Jane Doe",
+        "is_admin": false,
+        "role": null,
+        "access_role": "st",
+        "verified": true,
+        "email": "jane.doe@company.com",
+        "icon": "https://pics.site.com/1234.jpg"
+      },
+      "modified": "2018-09-11T06:38:09.000000+00:00"
+    }
+  ]
+}


### PR DESCRIPTION
Issue #185

If applied this Pull request will add some of the missing fields to `DashboardLite` and adds a generated `datadog-accessors.go` file.
Specifically:
 - `ReadOnly` type `bool`
 - `Created` type `string`
 - `Modified` type `string`
 - `CreatedBy` type `CreatedBy`

A custom type `CreatedBy` has the following fields:
 - `Disabled` type `bool`
 - `Handle` type `string`
 - `Name` type `string`
 - `IsAdmin` type `bool`
 - `Role` type `string`
 - `AccessRole` type string
 - `Verified` type `bool`
 - `Email` type `string`
 - `Icon` type `string`

PR also includes a unittest.