### PR TITLE
Add support for units and includeZero in Yaxis

### DIFF
--- a/dashboards.go
+++ b/dashboards.go
@@ -52,11 +52,13 @@ type GraphEvent struct {
 }
 
 type Yaxis struct {
-	Min     *float64 `json:"min,omitempty"`
-	AutoMin bool     `json:"-"`
-	Max     *float64 `json:"max,omitempty"`
-	AutoMax bool     `json:"-"`
-	Scale   *string  `json:"scale,omitempty"`
+	Min          *float64 `json:"min,omitempty"`
+	AutoMin      bool     `json:"-"`
+	Max          *float64 `json:"max,omitempty"`
+	AutoMax      bool     `json:"-"`
+	Scale        *string  `json:"scale,omitempty"`
+	IncludeZero  *bool    `json:"includeZero,omitempty"`
+	IncludeUnits *bool    `json:"units,omitempty"`
 }
 
 // UnmarshalJSON is a Custom Unmarshal for Yaxis.Min/Yaxis.Max. If the datadog API

--- a/dashboards_test.go
+++ b/dashboards_test.go
@@ -25,27 +25,33 @@ type YAxisTestSuite struct {
 
 func (suite *YAxisTestSuite) SetupTest() {
 	// Custom Y.Min, Y.Max
-	suite.yJSON = []byte(`{"min":0,"max":1,"scale":"linear"}`)
+	suite.yJSON = []byte(`{"min":0,"max":1,"scale":"linear","includeZero":true,"units":true}`)
 	suite.yMarshalledJSON = suite.yJSON
 	yMinFloat := float64(0)
 	yMaxFloat := float64(1)
 	yScale := "linear"
+	yIncludeZero := true
+	yIncludeUnits := true
 	suite.y = Yaxis{
-		Min:     &yMinFloat,
-		AutoMin: false,
-		Max:     &yMaxFloat,
-		AutoMax: false,
-		Scale:   &yScale,
+		Min:          &yMinFloat,
+		AutoMin:      false,
+		Max:          &yMaxFloat,
+		AutoMax:      false,
+		Scale:        &yScale,
+		IncludeZero:  &yIncludeZero,
+		IncludeUnits: &yIncludeUnits,
 	}
 	// Auto Y.Min, Y.Max
-	suite.yAutoMinMaxJSON = []byte(`{"min":"auto","max":"auto","scale":"linear"}`)
-	suite.yAutoMinMaxMarshalledJSON = []byte(`{"scale":"linear"}`)
+	suite.yAutoMinMaxJSON = []byte(`{"min":"auto","max":"auto","scale":"linear","includeZero":true,"units":true}`)
+	suite.yAutoMinMaxMarshalledJSON = []byte(`{"scale":"linear","includeZero":true,"units":true}`)
 	suite.yAutoMinMax = Yaxis{
-		Min:     nil,
-		AutoMin: true,
-		Max:     nil,
-		AutoMax: true,
-		Scale:   &yScale,
+		Min:          nil,
+		AutoMin:      true,
+		Max:          nil,
+		AutoMax:      true,
+		Scale:        &yScale,
+		IncludeZero:  &yIncludeZero,
+		IncludeUnits: &yIncludeUnits,
 	}
 }
 

--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -10770,6 +10770,68 @@ func (w *Widget) SetY(v int) {
 	w.Y = &v
 }
 
+// GetIncludeUnits returns the IncludeUnits field if non-nil, zero value otherwise.
+func (y *Yaxis) GetIncludeUnits() bool {
+	if y == nil || y.IncludeUnits == nil {
+		return false
+	}
+	return *y.IncludeUnits
+}
+
+// GetIncludeUnitsOk returns a tuple with the IncludeUnits field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (y *Yaxis) GetIncludeUnitsOk() (bool, bool) {
+	if y == nil || y.IncludeUnits == nil {
+		return false, false
+	}
+	return *y.IncludeUnits, true
+}
+
+// HasIncludeUnits returns a boolean if a field has been set.
+func (y *Yaxis) HasIncludeUnits() bool {
+	if y != nil && y.IncludeUnits != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetIncludeUnits allocates a new y.IncludeUnits and returns the pointer to it.
+func (y *Yaxis) SetIncludeUnits(v bool) {
+	y.IncludeUnits = &v
+}
+
+// GetIncludeZero returns the IncludeZero field if non-nil, zero value otherwise.
+func (y *Yaxis) GetIncludeZero() bool {
+	if y == nil || y.IncludeZero == nil {
+		return false
+	}
+	return *y.IncludeZero
+}
+
+// GetIncludeZeroOk returns a tuple with the IncludeZero field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (y *Yaxis) GetIncludeZeroOk() (bool, bool) {
+	if y == nil || y.IncludeZero == nil {
+		return false, false
+	}
+	return *y.IncludeZero, true
+}
+
+// HasIncludeZero returns a boolean if a field has been set.
+func (y *Yaxis) HasIncludeZero() bool {
+	if y != nil && y.IncludeZero != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetIncludeZero allocates a new y.IncludeZero and returns the pointer to it.
+func (y *Yaxis) SetIncludeZero(v bool) {
+	y.IncludeZero = &v
+}
+
 // GetMax returns the Max field if non-nil, zero value otherwise.
 func (y *Yaxis) GetMax() float64 {
 	if y == nil || y.Max == nil {


### PR DESCRIPTION
* Adds IncludeZero to support whether to always include zero or not.
Default is to always include zero.
* Adds IncludeUnits (units in Datadog json) to determine whether to show
the unit label to the left of the yaxis or not.