### PR TITLE
Move back Precision to string type

### DIFF
--- a/dashboards.go
+++ b/dashboards.go
@@ -123,10 +123,10 @@ type GraphDefinition struct {
 	Yaxis Yaxis `json:"yaxis,omitempty"`
 
 	// For query value type graphs
-	Autoscale  *bool        `json:"autoscale,omitempty"`
-	TextAlign  *string      `json:"text_align,omitempty"`
-	Precision  *json.Number `json:"precision,omitempty"`
-	CustomUnit *string      `json:"custom_unit,omitempty"`
+	Autoscale  *bool   `json:"autoscale,omitempty"`
+	TextAlign  *string `json:"text_align,omitempty"`
+	Precision  *string `json:"precision,omitempty"`
+	CustomUnit *string `json:"custom_unit,omitempty"`
 
 	// For hostmaps
 	Style                 *Style   `json:"style,omitempty"`

--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -2897,7 +2897,7 @@ func (g *GraphDefinition) SetNodeType(v string) {
 }
 
 // GetPrecision returns the Precision field if non-nil, zero value otherwise.
-func (g *GraphDefinition) GetPrecision() json.Number {
+func (g *GraphDefinition) GetPrecision() string {
 	if g == nil || g.Precision == nil {
 		return ""
 	}
@@ -2906,7 +2906,7 @@ func (g *GraphDefinition) GetPrecision() json.Number {
 
 // GetPrecisionOk returns a tuple with the Precision field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (g *GraphDefinition) GetPrecisionOk() (json.Number, bool) {
+func (g *GraphDefinition) GetPrecisionOk() (string, bool) {
 	if g == nil || g.Precision == nil {
 		return "", false
 	}
@@ -2923,7 +2923,7 @@ func (g *GraphDefinition) HasPrecision() bool {
 }
 
 // SetPrecision allocates a new g.Precision and returns the pointer to it.
-func (g *GraphDefinition) SetPrecision(v json.Number) {
+func (g *GraphDefinition) SetPrecision(v string) {
 	g.Precision = &v
 }
 
@@ -7795,7 +7795,7 @@ func (t *TileDef) SetNoMetricHosts(v bool) {
 }
 
 // GetPrecision returns the Precision field if non-nil, zero value otherwise.
-func (t *TileDef) GetPrecision() json.Number {
+func (t *TileDef) GetPrecision() string {
 	if t == nil || t.Precision == nil {
 		return ""
 	}
@@ -7804,7 +7804,7 @@ func (t *TileDef) GetPrecision() json.Number {
 
 // GetPrecisionOk returns a tuple with the Precision field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (t *TileDef) GetPrecisionOk() (json.Number, bool) {
+func (t *TileDef) GetPrecisionOk() (string, bool) {
 	if t == nil || t.Precision == nil {
 		return "", false
 	}
@@ -7821,7 +7821,7 @@ func (t *TileDef) HasPrecision() bool {
 }
 
 // SetPrecision allocates a new t.Precision and returns the pointer to it.
-func (t *TileDef) SetPrecision(v json.Number) {
+func (t *TileDef) SetPrecision(v string) {
 	t.Precision = &v
 }
 

--- a/integration/screen_widgets_test.go
+++ b/integration/screen_widgets_test.go
@@ -91,7 +91,7 @@ func TestWidgets(t *testing.T) {
 				}},
 				CustomUnit: datadog.String("%"),
 				Autoscale:  datadog.Bool(false),
-				Precision:  datadog.JsonNumber("6"),
+				Precision:  datadog.String("6"),
 				TextAlign:  datadog.String("right"),
 			},
 		},

--- a/screen_widgets.go
+++ b/screen_widgets.go
@@ -9,7 +9,7 @@ type TileDef struct {
 	Viz        *string          `json:"viz,omitempty"`
 	CustomUnit *string          `json:"custom_unit,omitempty"`
 	Autoscale  *bool            `json:"autoscale,omitempty"`
-	Precision  *json.Number     `json:"precision,omitempty"`
+	Precision  *string          `json:"precision,omitempty"`
 	TextAlign  *string          `json:"text_align,omitempty"`
 
 	// For hostmap


### PR DESCRIPTION
#179 Changed the type of `Precision` fields for various struct from `*string` to `*json.Number` but I can't make it work due to the fact that `"*"` is a valid value, meaning "full precision". Please notice acceptance tests don't expose the issue since `Precision` field for `Widget` (the one used in the tests) is still a string: https://github.com/zorkian/go-datadog-api/blob/ae3affd1a9e7b1798f38ad1257b5916b7e6ede00/screen_widgets.go#L109

Not sure what was the rationale around #179 since it mentions the API might return `int` for `precision` sometimes but if that's the case we should fix the issue on the Datadog side, normalizing all the things to strings.

This is blocking an important fix for https://github.com/terraform-providers/terraform-provider-datadog/issues/117