### PR TITLE
Fix #192 screenboard width and height should support string

### DIFF
--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -6369,18 +6369,18 @@ func (r *Rule) SetTimeframe(v string) {
 }
 
 // GetHeight returns the Height field if non-nil, zero value otherwise.
-func (s *Screenboard) GetHeight() int {
+func (s *Screenboard) GetHeight() json.Number {
 	if s == nil || s.Height == nil {
-		return 0
+		return ""
 	}
 	return *s.Height
 }
 
 // GetHeightOk returns a tuple with the Height field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (s *Screenboard) GetHeightOk() (int, bool) {
+func (s *Screenboard) GetHeightOk() (json.Number, bool) {
 	if s == nil || s.Height == nil {
-		return 0, false
+		return "", false
 	}
 	return *s.Height, true
 }
@@ -6395,7 +6395,7 @@ func (s *Screenboard) HasHeight() bool {
 }
 
 // SetHeight allocates a new s.Height and returns the pointer to it.
-func (s *Screenboard) SetHeight(v int) {
+func (s *Screenboard) SetHeight(v json.Number) {
 	s.Height = &v
 }
 
@@ -6524,18 +6524,18 @@ func (s *Screenboard) SetTitle(v string) {
 }
 
 // GetWidth returns the Width field if non-nil, zero value otherwise.
-func (s *Screenboard) GetWidth() int {
+func (s *Screenboard) GetWidth() json.Number {
 	if s == nil || s.Width == nil {
-		return 0
+		return ""
 	}
 	return *s.Width
 }
 
 // GetWidthOk returns a tuple with the Width field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (s *Screenboard) GetWidthOk() (int, bool) {
+func (s *Screenboard) GetWidthOk() (json.Number, bool) {
 	if s == nil || s.Width == nil {
-		return 0, false
+		return "", false
 	}
 	return *s.Width, true
 }
@@ -6550,7 +6550,7 @@ func (s *Screenboard) HasWidth() bool {
 }
 
 // SetWidth allocates a new s.Width and returns the pointer to it.
-func (s *Screenboard) SetWidth(v int) {
+func (s *Screenboard) SetWidth(v json.Number) {
 	s.Width = &v
 }
 

--- a/integration/screenboards_test.go
+++ b/integration/screenboards_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/zorkian/go-datadog-api"
@@ -93,8 +94,8 @@ func TestScreenboardGet(t *testing.T) {
 func getTestScreenboard() *datadog.Screenboard {
 	return &datadog.Screenboard{
 		Title:   datadog.String("___Test-Board___"),
-		Height:  datadog.Int(600),
-		Width:   datadog.Int(800),
+		Height:  datadog.JsonNumber(json.Number("600")),
+		Width:   datadog.JsonNumber(json.Number("800")),
 		Widgets: []datadog.Widget{},
 	}
 }
@@ -129,10 +130,10 @@ func assertScreenboardEquals(t *testing.T, actual, expected *datadog.Screenboard
 		t.Errorf("Screenboard title does not match: %s != %s", *actual.Title, *expected.Title)
 	}
 	if *actual.Width != *expected.Width {
-		t.Errorf("Screenboard width does not match: %d != %d", *actual.Width, *expected.Width)
+		t.Errorf("Screenboard width does not match: %s != %s", *actual.Width, *expected.Width)
 	}
 	if *actual.Height != *expected.Height {
-		t.Errorf("Screenboard width does not match: %d != %d", *actual.Height, *expected.Height)
+		t.Errorf("Screenboard width does not match: %s != %s", *actual.Height, *expected.Height)
 	}
 	if len(actual.Widgets) != len(expected.Widgets) {
 		t.Errorf("Number of Screenboard widgets does not match: %d != %d", len(actual.Widgets), len(expected.Widgets))

--- a/screenboards.go
+++ b/screenboards.go
@@ -9,6 +9,7 @@
 package datadog
 
 import (
+	"encoding/json"
 	"fmt"
 )
 
@@ -17,8 +18,8 @@ import (
 type Screenboard struct {
 	Id                *int               `json:"id,omitempty"`
 	Title             *string            `json:"board_title,omitempty"`
-	Height            *int               `json:"height,omitempty"`
-	Width             *int               `json:"width,omitempty"`
+	Height            *json.Number       `json:"height,omitempty"`
+	Width             *json.Number       `json:"width,omitempty"`
 	Shared            *bool              `json:"shared,omitempty"`
 	TemplateVariables []TemplateVariable `json:"template_variables,omitempty"`
 	Widgets           []Widget           `json:"widgets"`

--- a/screenboards_test.go
+++ b/screenboards_test.go
@@ -37,14 +37,16 @@ func TestGetScreenboard(t *testing.T) {
 		t.Fatalf("expect title %s. Got %s", expectedTitle, title)
 	}
 
-	expectedHeight := 768
-	if height := screenboard.GetHeight(); height != expectedHeight {
-		t.Fatalf("expect height %d. Got %d", expectedHeight, height)
+	expectedHeight := int64(768)
+	height := screenboard.GetHeight()
+	if h, err := height.Int64(); err != nil || h != expectedHeight {
+		t.Fatalf("expect height %d. Got %s", expectedHeight, height)
 	}
 
-	expectedWidth := 1024
-	if width := screenboard.GetWidth(); width != expectedWidth {
-		t.Fatalf("expect width %d. Got %d", expectedWidth, width)
+	expectedWidth := int64(1024)
+	width := screenboard.GetWidth()
+	if w, err := width.Int64(); err != nil || w != expectedWidth {
+		t.Fatalf("expect width %d. Got %s", expectedWidth, width)
 	}
 
 	expectedReadOnly := false
@@ -59,6 +61,37 @@ func TestGetScreenboard(t *testing.T) {
 
 	for _, widget := range screenboard.Widgets {
 		validateWidget(t, widget)
+	}
+}
+
+func TestGetScreenboardWithWidhtHeightAsString(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response, err := ioutil.ReadFile("./tests/fixtures/screenboard_response_strings.json")
+		if err != nil {
+			t.Fatal(err)
+		}
+		w.Write(response)
+	}))
+	defer ts.Close()
+
+	datadogClient := Client{
+		baseUrl:    ts.URL,
+		HttpClient: http.DefaultClient,
+	}
+
+	screenboard, err := datadogClient.GetScreenboard(6334)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedHeight := "768"
+	if height := screenboard.GetHeight(); height.String() != expectedHeight {
+		t.Fatalf("expect height %s. Got %s", expectedHeight, height.String())
+	}
+
+	expectedWidth := "100%"
+	if width := screenboard.GetWidth(); width.String() != expectedWidth {
+		t.Fatalf("expect width %s. Got %s", expectedWidth, width.String())
 	}
 }
 

--- a/tests/fixtures/screenboard_response_strings.json
+++ b/tests/fixtures/screenboard_response_strings.json
@@ -1,0 +1,19 @@
+{
+  "board_title": "dogapi test",
+  "height": "768",
+  "id": 6334,
+  "widgets": [
+    {
+      "height": 20,
+      "type": "image",
+      "url": "http://path/to/image.jpg",
+      "width": 32,
+      "x": 32,
+      "y": 7
+    }
+  ],
+  "width": "100%",
+  "created": "2015-12-17T23:06:06.703087+00:00",
+  "modified": "2015-12-17T23:12:26.726234+00:00",
+  "read_only": false
+}


### PR DESCRIPTION
Datadog API for screenboards width and height can return either numbers, number as strings (like “1024”) or even strings (like “100%”).

The recent fix #190 changed those fields to be only ints, breaking the compatibility with some datadog screen boards (notably the ones returning "100%").

As suggested in #192 this change fixes the issue by making the fields become `json.Number` which should cover all possible returned values.
