### PR TITLE
Add enable_logs_sample option for log monitor

### DIFF
--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -5469,6 +5469,37 @@ func (m *Monitor) SetType(v string) {
 	m.Type = &v
 }
 
+// GetEnableLogsSample returns the EnableLogsSample field if non-nil, zero value otherwise.
+func (o *Options) GetEnableLogsSample() bool {
+	if o == nil || o.EnableLogsSample == nil {
+		return false
+	}
+	return *o.EnableLogsSample
+}
+
+// GetEnableLogsSampleOk returns a tuple with the EnableLogsSample field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (o *Options) GetEnableLogsSampleOk() (bool, bool) {
+	if o == nil || o.EnableLogsSample == nil {
+		return false, false
+	}
+	return *o.EnableLogsSample, true
+}
+
+// HasEnableLogsSample returns a boolean if a field has been set.
+func (o *Options) HasEnableLogsSample() bool {
+	if o != nil && o.EnableLogsSample != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetEnableLogsSample allocates a new o.EnableLogsSample and returns the pointer to it.
+func (o *Options) SetEnableLogsSample(v bool) {
+	o.EnableLogsSample = &v
+}
+
 // GetEscalationMessage returns the EscalationMessage field if non-nil, zero value otherwise.
 func (o *Options) GetEscalationMessage() string {
 	if o == nil || o.EscalationMessage == nil {

--- a/monitors.go
+++ b/monitors.go
@@ -61,6 +61,7 @@ type Options struct {
 	IncludeTags       *bool             `json:"include_tags,omitempty"`
 	RequireFullWindow *bool             `json:"require_full_window,omitempty"`
 	Locked            *bool             `json:"locked,omitempty"`
+	EnableLogsSample  *bool             `json:"enable_logs_sample,omitempty"`
 }
 
 type TriggeringValue struct {


### PR DESCRIPTION
Hi, this pull request adds enable_logs_sample option for log monitor.

![2018-11-23 16 19 54](https://user-images.githubusercontent.com/6387224/48931830-a7ac5c80-ef3b-11e8-8fac-8b89bce9af11.png)
