### PR TITLE
Fix custom type name for reuse

### DIFF
--- a/cmd/tools/gen-accessors.go
+++ b/cmd/tools/gen-accessors.go
@@ -185,7 +185,7 @@ func (t *templateData) addIdent(x *ast.Ident, receiverType, fieldName string) {
 		zeroValue = "0"
 	case "Status":
 		zeroValue = "0"
-	case "PrecisionT":
+	case "StrintD":
 		zeroValue = `""`
 	default:
 		zeroValue = fmt.Sprintf("%s{}", x.String())

--- a/common.go
+++ b/common.go
@@ -1,0 +1,29 @@
+package datadog
+
+import "encoding/json"
+
+// StrintD ...
+type StrintD string
+
+// UnmarshalJSON is a Custom Unmarshal for StrintD. The Datadog API can
+// return 1 (int), "1" (number, but a string type) or something like "100%" or
+// "*" (string).
+func (s *StrintD) UnmarshalJSON(data []byte) error {
+	var err error
+	var strintNumber json.Number
+	if err = json.Unmarshal(data, &strintNumber); err == nil {
+		*s = StrintD(strintNumber)
+		return nil
+	}
+
+	var strintStr StrintD
+	if err = json.Unmarshal(data, &strintStr); err == nil {
+		*s = StrintD(strintStr)
+		return nil
+	}
+
+	var s0 StrintD
+	*s = s0
+
+	return err
+}

--- a/dashboards.go
+++ b/dashboards.go
@@ -123,10 +123,10 @@ type GraphDefinition struct {
 	Yaxis Yaxis `json:"yaxis,omitempty"`
 
 	// For query value type graphs
-	Autoscale  *bool       `json:"autoscale,omitempty"`
-	TextAlign  *string     `json:"text_align,omitempty"`
-	Precision  *PrecisionT `json:"precision,omitempty"`
-	CustomUnit *string     `json:"custom_unit,omitempty"`
+	Autoscale  *bool    `json:"autoscale,omitempty"`
+	TextAlign  *string  `json:"text_align,omitempty"`
+	Precision  *StrintD `json:"precision,omitempty"`
+	CustomUnit *string  `json:"custom_unit,omitempty"`
 
 	// For hostmaps
 	Style                 *Style   `json:"style,omitempty"`

--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -2897,7 +2897,7 @@ func (g *GraphDefinition) SetNodeType(v string) {
 }
 
 // GetPrecision returns the Precision field if non-nil, zero value otherwise.
-func (g *GraphDefinition) GetPrecision() PrecisionT {
+func (g *GraphDefinition) GetPrecision() StrintD {
 	if g == nil || g.Precision == nil {
 		return ""
 	}
@@ -2906,7 +2906,7 @@ func (g *GraphDefinition) GetPrecision() PrecisionT {
 
 // GetPrecisionOk returns a tuple with the Precision field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (g *GraphDefinition) GetPrecisionOk() (PrecisionT, bool) {
+func (g *GraphDefinition) GetPrecisionOk() (StrintD, bool) {
 	if g == nil || g.Precision == nil {
 		return "", false
 	}
@@ -2923,7 +2923,7 @@ func (g *GraphDefinition) HasPrecision() bool {
 }
 
 // SetPrecision allocates a new g.Precision and returns the pointer to it.
-func (g *GraphDefinition) SetPrecision(v PrecisionT) {
+func (g *GraphDefinition) SetPrecision(v StrintD) {
 	g.Precision = &v
 }
 
@@ -7826,7 +7826,7 @@ func (t *TileDef) SetNoMetricHosts(v bool) {
 }
 
 // GetPrecision returns the Precision field if non-nil, zero value otherwise.
-func (t *TileDef) GetPrecision() PrecisionT {
+func (t *TileDef) GetPrecision() StrintD {
 	if t == nil || t.Precision == nil {
 		return ""
 	}
@@ -7835,7 +7835,7 @@ func (t *TileDef) GetPrecision() PrecisionT {
 
 // GetPrecisionOk returns a tuple with the Precision field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (t *TileDef) GetPrecisionOk() (PrecisionT, bool) {
+func (t *TileDef) GetPrecisionOk() (StrintD, bool) {
 	if t == nil || t.Precision == nil {
 		return "", false
 	}
@@ -7852,7 +7852,7 @@ func (t *TileDef) HasPrecision() bool {
 }
 
 // SetPrecision allocates a new t.Precision and returns the pointer to it.
-func (t *TileDef) SetPrecision(v PrecisionT) {
+func (t *TileDef) SetPrecision(v StrintD) {
 	t.Precision = &v
 }
 
@@ -10120,7 +10120,7 @@ func (w *Widget) SetParams(v Params) {
 }
 
 // GetPrecision returns the Precision field if non-nil, zero value otherwise.
-func (w *Widget) GetPrecision() PrecisionT {
+func (w *Widget) GetPrecision() StrintD {
 	if w == nil || w.Precision == nil {
 		return ""
 	}
@@ -10129,7 +10129,7 @@ func (w *Widget) GetPrecision() PrecisionT {
 
 // GetPrecisionOk returns a tuple with the Precision field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (w *Widget) GetPrecisionOk() (PrecisionT, bool) {
+func (w *Widget) GetPrecisionOk() (StrintD, bool) {
 	if w == nil || w.Precision == nil {
 		return "", false
 	}
@@ -10146,7 +10146,7 @@ func (w *Widget) HasPrecision() bool {
 }
 
 // SetPrecision allocates a new w.Precision and returns the pointer to it.
-func (w *Widget) SetPrecision(v PrecisionT) {
+func (w *Widget) SetPrecision(v StrintD) {
 	w.Precision = &v
 }
 

--- a/helpers.go
+++ b/helpers.go
@@ -66,16 +66,16 @@ func GetJsonNumberOk(v *json.Number) (json.Number, bool) {
 	return "", false
 }
 
-// Precision is a helper routine that allocates a new precision value
+// Strint is a helper routine that allocates a new strint value
 // to store v and returns a pointer to it.
-func Precision(v PrecisionT) *PrecisionT { return &v }
+func Strint(v StrintD) *StrintD { return &v }
 
-// GetPrecision is a helper routine that returns a boolean representing
+// GetStrint is a helper routine that returns a boolean representing
 // if a value was set, and if so, dereferences the pointer to it.
-func GetPrecision(v *PrecisionT) (PrecisionT, bool) {
+func GetStrint(v *StrintD) (StrintD, bool) {
 	if v != nil {
 		return *v, true
 	}
 
-	return PrecisionT(""), false
+	return StrintD(""), false
 }

--- a/screen_widgets.go
+++ b/screen_widgets.go
@@ -2,31 +2,6 @@ package datadog
 
 import "encoding/json"
 
-type PrecisionT string
-
-// UnmarshalJSON is a Custom Unmarshal for PrecisionT. The Datadog API can
-// return 1 (int), "1" (number, but a string type) or something like "100%" or
-// "*" (string).
-func (p *PrecisionT) UnmarshalJSON(data []byte) error {
-	var err error
-	var precisionNum json.Number
-	if err = json.Unmarshal(data, &precisionNum); err == nil {
-		*p = PrecisionT(precisionNum)
-		return nil
-	}
-
-	var precisionStr string
-	if err = json.Unmarshal(data, &precisionStr); err == nil {
-		*p = PrecisionT(precisionStr)
-		return nil
-	}
-
-	var p0 PrecisionT
-	*p = p0
-
-	return err
-}
-
 type TileDef struct {
 	Events     []TileDefEvent   `json:"events,omitempty"`
 	Markers    []TileDefMarker  `json:"markers,omitempty"`
@@ -34,7 +9,7 @@ type TileDef struct {
 	Viz        *string          `json:"viz,omitempty"`
 	CustomUnit *string          `json:"custom_unit,omitempty"`
 	Autoscale  *bool            `json:"autoscale,omitempty"`
-	Precision  *PrecisionT      `json:"precision,omitempty"`
+	Precision  *StrintD         `json:"precision,omitempty"`
 	TextAlign  *string          `json:"text_align,omitempty"`
 
 	// For hostmap
@@ -129,9 +104,9 @@ type Widget struct {
 	Color *string `json:"color,omitempty"`
 
 	// For AlertValue widget
-	TextSize  *string     `json:"text_size,omitempty"`
-	Unit      *string     `json:"unit,omitempty"`
-	Precision *PrecisionT `json:"precision,omitempty"`
+	TextSize  *string  `json:"text_size,omitempty"`
+	Unit      *string  `json:"unit,omitempty"`
+	Precision *StrintD `json:"precision,omitempty"`
 
 	// AlertGraph widget
 	VizType *string `json:"viz_type,omitempty"`


### PR DESCRIPTION
# Abstract
Fix Custom data type `PrecisionT` to `StrintD`. (comes from: `String & Int data type for datadog`)
Custom data type `PrecisionT` can reuse for other params.  (like width/heght in #195 ).
But reuse in other param, the data name would confuse users.

