### PR TITLE
Fix screen widget FillMin and FillMax type matching

### DIFF
--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -4,7 +4,7 @@
  *
  * Please see the included LICENSE file for licensing information.
  *
- * Copyright 2018 by authors and contributors.
+ * Copyright 2019 by authors and contributors.
 */
 
 package datadog
@@ -8601,7 +8601,7 @@ func (t *TileDefRequestStyle) SetWidth(v string) {
 }
 
 // GetFillMax returns the FillMax field if non-nil, zero value otherwise.
-func (t *TileDefStyle) GetFillMax() string {
+func (t *TileDefStyle) GetFillMax() json.Number {
 	if t == nil || t.FillMax == nil {
 		return ""
 	}
@@ -8610,7 +8610,7 @@ func (t *TileDefStyle) GetFillMax() string {
 
 // GetFillMaxOk returns a tuple with the FillMax field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (t *TileDefStyle) GetFillMaxOk() (string, bool) {
+func (t *TileDefStyle) GetFillMaxOk() (json.Number, bool) {
 	if t == nil || t.FillMax == nil {
 		return "", false
 	}
@@ -8627,12 +8627,12 @@ func (t *TileDefStyle) HasFillMax() bool {
 }
 
 // SetFillMax allocates a new t.FillMax and returns the pointer to it.
-func (t *TileDefStyle) SetFillMax(v string) {
+func (t *TileDefStyle) SetFillMax(v json.Number) {
 	t.FillMax = &v
 }
 
 // GetFillMin returns the FillMin field if non-nil, zero value otherwise.
-func (t *TileDefStyle) GetFillMin() string {
+func (t *TileDefStyle) GetFillMin() json.Number {
 	if t == nil || t.FillMin == nil {
 		return ""
 	}
@@ -8641,7 +8641,7 @@ func (t *TileDefStyle) GetFillMin() string {
 
 // GetFillMinOk returns a tuple with the FillMin field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (t *TileDefStyle) GetFillMinOk() (string, bool) {
+func (t *TileDefStyle) GetFillMinOk() (json.Number, bool) {
 	if t == nil || t.FillMin == nil {
 		return "", false
 	}
@@ -8658,7 +8658,7 @@ func (t *TileDefStyle) HasFillMin() bool {
 }
 
 // SetFillMin allocates a new t.FillMin and returns the pointer to it.
-func (t *TileDefStyle) SetFillMin(v string) {
+func (t *TileDefStyle) SetFillMin(v json.Number) {
 	t.FillMin = &v
 }
 

--- a/integration/screen_widgets_test.go
+++ b/integration/screen_widgets_test.go
@@ -312,8 +312,8 @@ func TestWidgets(t *testing.T) {
 				Style: &datadog.TileDefStyle{
 					Palette:     datadog.String("hostmap_blues"),
 					PaletteFlip: datadog.String("true"),
-					FillMin:     datadog.String("20"),
-					FillMax:     datadog.String("300"),
+					FillMin:     datadog.JsonNumber("20"),
+					FillMax:     datadog.JsonNumber("300"),
 				},
 			},
 		},

--- a/screen_widgets.go
+++ b/screen_widgets.go
@@ -96,10 +96,10 @@ type TileDefRequestStyle struct {
 }
 
 type TileDefStyle struct {
-	Palette     *string `json:"palette,omitempty"`
-	PaletteFlip *string `json:"paletteFlip,omitempty"`
-	FillMin     *string `json:"fillMin,omitempty"`
-	FillMax     *string `json:"fillMax,omitempty"`
+	Palette     *string      `json:"palette,omitempty"`
+	PaletteFlip *string      `json:"paletteFlip,omitempty"`
+	FillMin     *json.Number `json:"fillMin,omitempty"`
+	FillMax     *json.Number `json:"fillMax,omitempty"`
 }
 
 type Time struct {


### PR DESCRIPTION
`fillMax` and `fillMix` can be decimals, so importing a screenboard that includes those with `terraform import datadog_screenboard.<screenboard_name> <screenboard_id>` would throw an error like:

```
cannot unmarshal number into Go struct field TileDefStyle.fillMax of type string 
```

This PR attempts to fix it, based on https://github.com/zorkian/go-datadog-api/blob/master/dashboards.go#L112-L113. 
~Attempts to fix the type for `PaletteFlip` too.~