### PR TITLE
Use different Datadog test account per build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-  - "1.9"
   - "1.10.x"
   - "1.11.x"
   - "tip"
@@ -18,8 +17,7 @@ script:
   - golint ./... | grep -v vendor/
   - make
   - scripts/check-code-generation-ran.sh
-  # PR's don't have access to Travis EnvVars with DDog API Keys. Skip acceptance tests on PR.
-  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then make testacc; fi'
+  - scripts/acceptance-tests.sh
 
 matrix:
     allow_failures:

--- a/scripts/acceptance-tests.sh
+++ b/scripts/acceptance-tests.sh
@@ -11,14 +11,17 @@ case "$TRAVIS_GO_VERSION" in
     1.10*)
         export DATADOG_API_KEY=${DATADOG_API_KEY_A:?}
         export DATADOG_APP_KEY=${DATADOG_APP_KEY_A:?}
+        echo "Using Datadog 'A' test account"
         ;;
     1.11*)
         export DATADOG_API_KEY=${DATADOG_API_KEY_B:?}
         export DATADOG_APP_KEY=${DATADOG_APP_KEY_B:?}
+        echo "Using Datadog 'B' test account"
         ;;
     *)
         export DATADOG_API_KEY=${DATADOG_API_KEY_C:?}
         export DATADOG_APP_KEY=${DATADOG_APP_KEY_C:?}
+        echo "Using Datadog 'C' test account"
         ;;
 esac
 

--- a/scripts/acceptance-tests.sh
+++ b/scripts/acceptance-tests.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+
+if [ "$TRAVIS_PULL_REQUEST" = "true" ]; then
+    echo "Not running acceptance tests for pull requests"
+    exit 0
+fi
+
+# Using multiple Datadog accounts to minimise flakiness during parallel runs, as some tests rely
+# an amount of items across a whole account.
+case "$TRAVIS_GO_VERSION" in
+    1.10*)
+        export DATADOG_API_KEY=${DATADOG_API_KEY_A:?}
+        export DATADOG_APP_KEY=${DATADOG_APP_KEY_A:?}
+        ;;
+    1.11*)
+        export DATADOG_API_KEY=${DATADOG_API_KEY_B:?}
+        export DATADOG_APP_KEY=${DATADOG_APP_KEY_B:?}
+        ;;
+    *)
+        export DATADOG_API_KEY=${DATADOG_API_KEY_C:?}
+        export DATADOG_APP_KEY=${DATADOG_APP_KEY_C:?}
+        ;;
+esac
+
+echo "Running acceptance tests"
+make testacc

--- a/scripts/acceptance-tests.sh
+++ b/scripts/acceptance-tests.sh
@@ -26,4 +26,4 @@ case "$TRAVIS_GO_VERSION" in
 esac
 
 echo "Running acceptance tests"
-make testacc
+GOCACHE=off make testacc

--- a/scripts/check-code-generation-ran.sh
+++ b/scripts/check-code-generation-ran.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env sh
+
 # Make generate will always update datadog-accessors.go
 cp datadog-accessors.go datadog-accessors.go.bak
 
@@ -9,7 +11,7 @@ changed=$?
 rm datadog-accessors.go.bak
 
 # See if contents have changed and error if they have
-if [[ $changed != 0 ]] ; then
+if [ $changed != 0 ] ; then
     echo "Did you run 'make generate' before committing?"
     exit 1
 fi

--- a/scripts/check-fmt.sh
+++ b/scripts/check-fmt.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 
-diff -u <(echo -n) <(gofmt -s -d $(find . -name '*.go' | grep -v vendor))
-
-# See if contents have changed and error if they have
-if [[ $? != 0 ]] ; then
+if ! diff -u <(echo -n) <(gofmt -s -d "$(find . -name '*.go' | grep -v vendor)")
+then
+    # See if contents have changed and error if they have
     echo "Did you run 'make fmt' before committing?"
     exit 1
 fi


### PR DESCRIPTION
This should remove build flake. Tests create and destroy resources, but use
the total amount to determine success. This will not work well if we run
acceptance test for another language version in parallel.

Fixes #166 .