### PR TITLE
[dashboards] Support getting dashboards by string id

### DIFF
--- a/dashboards.go
+++ b/dashboards.go
@@ -154,6 +154,7 @@ type TemplateVariable struct {
 // struct when we load a dashboard in detail.
 type Dashboard struct {
 	Id                *int               `json:"id,omitempty"`
+	NewId       	  *string            `json:"new_id,omitempty"`
 	Description       *string            `json:"description,omitempty"`
 	Title             *string            `json:"title,omitempty"`
 	Graphs            []Graph            `json:"graphs,omitempty"`
@@ -210,9 +211,15 @@ type DashboardConditionalFormat struct {
 }
 
 // GetDashboard returns a single dashboard created on this account.
-func (client *Client) GetDashboard(id int) (*Dashboard, error) {
+func (client *Client) GetDashboard(id interface{}) (*Dashboard, error) {
+
+	stringId, err := GetStringId(id)
+	if err != nil {
+		return nil, err
+	}
+
 	var out reqGetDashboard
-	if err := client.doJsonRequest("GET", fmt.Sprintf("/v1/dash/%d", id), nil, &out); err != nil {
+	if err := client.doJsonRequest("GET", fmt.Sprintf("/v1/dash/%s", stringId), nil, &out); err != nil {
 		return nil, err
 	}
 	return out.Dashboard, nil

--- a/dashboards.go
+++ b/dashboards.go
@@ -154,7 +154,7 @@ type TemplateVariable struct {
 // struct when we load a dashboard in detail.
 type Dashboard struct {
 	Id                *int               `json:"id,omitempty"`
-	NewId       	  *string            `json:"new_id,omitempty"`
+	NewId             *string            `json:"new_id,omitempty"`
 	Description       *string            `json:"description,omitempty"`
 	Title             *string            `json:"title,omitempty"`
 	Graphs            []Graph            `json:"graphs,omitempty"`

--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -1346,6 +1346,37 @@ func (d *Dashboard) SetId(v int) {
 	d.Id = &v
 }
 
+// GetNewId returns the NewId field if non-nil, zero value otherwise.
+func (d *Dashboard) GetNewId() string {
+	if d == nil || d.NewId == nil {
+		return ""
+	}
+	return *d.NewId
+}
+
+// GetNewIdOk returns a tuple with the NewId field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (d *Dashboard) GetNewIdOk() (string, bool) {
+	if d == nil || d.NewId == nil {
+		return "", false
+	}
+	return *d.NewId, true
+}
+
+// HasNewId returns a boolean if a field has been set.
+func (d *Dashboard) HasNewId() bool {
+	if d != nil && d.NewId != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetNewId allocates a new d.NewId and returns the pointer to it.
+func (d *Dashboard) SetNewId(v string) {
+	d.NewId = &v
+}
+
 // GetReadOnly returns the ReadOnly field if non-nil, zero value otherwise.
 func (d *Dashboard) GetReadOnly() bool {
 	if d == nil || d.ReadOnly == nil {
@@ -6459,6 +6490,37 @@ func (s *Screenboard) HasId() bool {
 // SetId allocates a new s.Id and returns the pointer to it.
 func (s *Screenboard) SetId(v int) {
 	s.Id = &v
+}
+
+// GetNewId returns the NewId field if non-nil, zero value otherwise.
+func (s *Screenboard) GetNewId() string {
+	if s == nil || s.NewId == nil {
+		return ""
+	}
+	return *s.NewId
+}
+
+// GetNewIdOk returns a tuple with the NewId field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (s *Screenboard) GetNewIdOk() (string, bool) {
+	if s == nil || s.NewId == nil {
+		return "", false
+	}
+	return *s.NewId, true
+}
+
+// HasNewId returns a boolean if a field has been set.
+func (s *Screenboard) HasNewId() bool {
+	if s != nil && s.NewId != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetNewId allocates a new s.NewId and returns the pointer to it.
+func (s *Screenboard) SetNewId(v string) {
+	s.NewId = &v
 }
 
 // GetReadOnly returns the ReadOnly field if non-nil, zero value otherwise.

--- a/helper_test.go
+++ b/helper_test.go
@@ -106,3 +106,25 @@ func getTestMonitor() *datadog.Monitor {
 		Tags:    make([]string, 0),
 	}
 }
+
+func TestHelperGetStringId(t *testing.T) {
+	// Assert GetStringId returned the id without a change if it is a string
+	id, err := datadog.GetStringId("abc-xyz-123")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, id, "abc-xyz-123")
+
+	// Assert GetStringId returned the id as a string if it is an integer
+	id, err = datadog.GetStringId(123)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, id, "123")
+
+	// Assert GetStringId returned an error if the id type is boolean
+	_, err = datadog.GetStringId(true)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "unsupported id type")
+
+	// Assert GetStringId returned an error if the id type is float64
+	_, err = datadog.GetStringId(5.2)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "unsupported id type")
+}

--- a/helpers.go
+++ b/helpers.go
@@ -10,8 +10,8 @@ package datadog
 
 import (
 	"encoding/json"
-	"strconv"
 	"errors"
+	"strconv"
 )
 
 // Bool is a helper routine that allocates a new bool value
@@ -90,11 +90,11 @@ func GetPrecision(v *PrecisionT) (PrecisionT, bool) {
 // It return an error if the type is neither string or an integer
 func GetStringId(id interface{}) (string, error) {
 	switch v := id.(type) {
-		case int:
-			return strconv.Itoa(v), nil
-		case string:
-			return v, nil
-		default:
-			return "", errors.New("unsupported id type")
-		}
+	case int:
+		return strconv.Itoa(v), nil
+	case string:
+		return v, nil
+	default:
+		return "", errors.New("unsupported id type")
+	}
 }

--- a/helpers.go
+++ b/helpers.go
@@ -84,7 +84,7 @@ func GetPrecision(v *PrecisionT) (PrecisionT, bool) {
 	return PrecisionT(""), false
 }
 
-// GetStringId is a helper routine that allows screenboards and timebaords to be retrieved
+// GetStringId is a helper routine that allows screenboards and timeboards to be retrieved
 // by either the legacy numerical format or the new string format.
 // It returns the id as is if it is a string, converts it to a string if it is an integer.
 // It return an error if the type is neither string or an integer

--- a/helpers.go
+++ b/helpers.go
@@ -8,7 +8,11 @@
 
 package datadog
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"strconv"
+	"errors"
+)
 
 // Bool is a helper routine that allocates a new bool value
 // to store v and returns a pointer to it.
@@ -78,4 +82,19 @@ func GetPrecision(v *PrecisionT) (PrecisionT, bool) {
 	}
 
 	return PrecisionT(""), false
+}
+
+// GetStringId is a helper routine that allows screenboards and timebaords to be retrieved
+// by either the legacy numerical format or the new string format.
+// It returns the id as is if it is a string, converts it to a string if it is an integer.
+// It return an error if the type is neither string or an integer
+func GetStringId(id interface{}) (string, error) {
+	switch v := id.(type) {
+		case int:
+			return strconv.Itoa(v), nil
+		case string:
+			return v, nil
+		default:
+			return "", errors.New("unsupported id type")
+		}
 }

--- a/integration/dashboards_test.go
+++ b/integration/dashboards_test.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/zorkian/go-datadog-api"
 	"github.com/stretchr/testify/assert"
+	"github.com/zorkian/go-datadog-api"
 )
 
 func TestDashboardCreateAndDelete(t *testing.T) {

--- a/integration/dashboards_test.go
+++ b/integration/dashboards_test.go
@@ -131,7 +131,7 @@ func TestDashboardGetWithNewId(t *testing.T) {
 	}
 	assertDashboardEquals(t, actualWithNewId, expected)
 
-	// the ids are euqal whether fetching using the old or the new id
+	// the ids are equal whether fetching using the old or the new id
 	assert.Equal(t, *actualWithNewId.Id, *actual.Id)
 
 	// try to fetch it freshly using a string, but with a wrong value

--- a/integration/dashboards_test.go
+++ b/integration/dashboards_test.go
@@ -125,11 +125,14 @@ func TestDashboardGetWithNewId(t *testing.T) {
 	assertDashboardEquals(t, actual, expected)
 
 	// try to fetch it freshly using the new id format and compare it again
-	actual, err = client.GetDashboard(*actual.NewId)
+	actualWithNewId, err := client.GetDashboard(*actual.NewId)
 	if err != nil {
 		t.Fatalf("Retrieving a dashboard failed when it shouldn't. (%s)", err)
 	}
-	assertDashboardEquals(t, actual, expected)
+	assertDashboardEquals(t, actualWithNewId, expected)
+
+	// the ids are euqal whether fetching using the old or the new id
+	assert.Equal(t, *actualWithNewId.Id, *actual.Id)
 
 	// try to fetch it freshly using a string, but with a wrong value
 	actual, err = client.GetDashboard("random_string")

--- a/integration/screenboards_test.go
+++ b/integration/screenboards_test.go
@@ -112,11 +112,14 @@ func TestScreenboardGetWithNewId(t *testing.T) {
 	assertScreenboardEquals(t, actual, expected)
 
 	// try to fetch it freshly using the new id format and compare it again
-	actual, err = client.GetScreenboard(*actual.NewId)
+	actualWithNewId, err := client.GetScreenboard(*actual.NewId)
 	if err != nil {
 		t.Fatalf("Retrieving a screenboard failed when it shouldn't. (%s)", err)
 	}
-	assertScreenboardEquals(t, actual, expected)
+	assertScreenboardEquals(t, actualWithNewId, expected)
+
+	// the ids are equal whether fetching using the old or the new id
+	assert.Equal(t, *actualWithNewId.Id, *actual.Id)
 
 	// try to fetch it freshly using a string, but with a wrong value
 	actual, err = client.GetScreenboard("random_string")

--- a/integration/screenboards_test.go
+++ b/integration/screenboards_test.go
@@ -3,8 +3,8 @@ package integration
 import (
 	"testing"
 
-	"github.com/zorkian/go-datadog-api"
 	"github.com/stretchr/testify/assert"
+	"github.com/zorkian/go-datadog-api"
 )
 
 func TestScreenboardCreateAndDelete(t *testing.T) {

--- a/screenboards.go
+++ b/screenboards.go
@@ -16,7 +16,7 @@ import (
 // struct when we load a screenboard in detail.
 type Screenboard struct {
 	Id                *int               `json:"id,omitempty"`
-	NewId       	  *string            `json:"new_id,omitempty"`
+	NewId             *string            `json:"new_id,omitempty"`
 	Title             *string            `json:"board_title,omitempty"`
 	Height            *int               `json:"height,omitempty"`
 	Width             *int               `json:"width,omitempty"`

--- a/screenboards.go
+++ b/screenboards.go
@@ -16,6 +16,7 @@ import (
 // struct when we load a screenboard in detail.
 type Screenboard struct {
 	Id                *int               `json:"id,omitempty"`
+	NewId       	  *string            `json:"new_id,omitempty"`
 	Title             *string            `json:"board_title,omitempty"`
 	Height            *int               `json:"height,omitempty"`
 	Width             *int               `json:"width,omitempty"`
@@ -39,9 +40,14 @@ type reqGetScreenboards struct {
 }
 
 // GetScreenboard returns a single screenboard created on this account.
-func (client *Client) GetScreenboard(id int) (*Screenboard, error) {
+func (client *Client) GetScreenboard(id interface{}) (*Screenboard, error) {
+	stringId, err := GetStringId(id)
+	if err != nil {
+		return nil, err
+	}
+
 	out := &Screenboard{}
-	if err := client.doJsonRequest("GET", fmt.Sprintf("/v1/screen/%d", id), nil, out); err != nil {
+	if err := client.doJsonRequest("GET", fmt.Sprintf("/v1/screen/%s", stringId), nil, out); err != nil {
 		return nil, err
 	}
 	return out, nil

--- a/tests/fixtures/dashboards_response.json
+++ b/tests/fixtures/dashboards_response.json
@@ -7,6 +7,7 @@
       "title": "Dashboard 1",
       "created": "2018-10-05T12:32:01.000000+00:00",
       "id": "123",
+      "new_id": "abc-xyz-111",
       "created_by": {
         "disabled": true,
         "handle": "john.doe@company.com",
@@ -27,6 +28,7 @@
       "title": "Dashboard 2",
       "created": "2018-01-01T00:00:00.000000+00:00",
       "id": "1234",
+      "new_id": "abc-xyz-222",
       "created_by": {
         "disabled": false,
         "handle": "jane.doe@company.com",


### PR DESCRIPTION
Add the ability to use the new dashboard string ID format in `GetScreenboard()` and `GetDashboard()`.
Used in https://github.com/terraform-providers/terraform-provider-datadog/pull/165