### PR TITLE
Add missing status now returned by the API

### DIFF
--- a/integration/synthetics_test.go
+++ b/integration/synthetics_test.go
@@ -184,6 +184,7 @@ func getTestSynthetics() *datadog.SyntheticsTest {
 		Config:    c,
 		Options:   o,
 		Locations: []string{"aws:eu-central-1"},
+		Status:    datadog.String("live"),
 		Type:      datadog.String("api"),
 		Tags:      []string{"tag1:value1", "tag2:value2"},
 	}


### PR DESCRIPTION
The API changed to always return the status, so the integration test needs to be updated.