### PR TITLE
Add functionality to manipulate API keys

### DIFF
--- a/api_keys.go
+++ b/api_keys.go
@@ -1,0 +1,122 @@
+/*
+ * Datadog API for Go
+ *
+ * Please see the included LICENSE file for licensing information.
+ *
+ * Copyright 2019 by authors and contributors.
+ */
+
+package datadog
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+var createdTimeLayout = "2006-01-02 15:04:05"
+
+// APIKey represents and API key
+type APIKey struct {
+	CreatedBy *string    `json:"created_by,omitempty"`
+	Name      *string    `json:"name,omitemtpy"`
+	Key       *string    `json:"key,omitempty"`
+	Created   *time.Time `json:"created,omitempty"`
+}
+
+// reqAPIKeys retrieves a slice of all APIKeys.
+type reqAPIKeys struct {
+	APIKeys []APIKey `json:"api_keys,omitempty"`
+}
+
+// reqAPIKey is similar to reqAPIKeys, but used for values returned by /v1/api_key/<somekey>
+// which contain one object (not list) "api_key" (not "api_keys") containing the found key
+type reqAPIKey struct {
+	APIKey *APIKey `json:"api_key"`
+}
+
+// MarshalJSON is a custom method for handling datetime marshalling
+func (k APIKey) MarshalJSON() ([]byte, error) {
+	// Approach for custom (un)marshalling borrowed from http://choly.ca/post/go-json-marshalling/
+	type Alias APIKey
+	return json.Marshal(&struct {
+		Created *string `json:"created,omitempty"`
+		*Alias
+	}{
+		Created: String(k.Created.Format(createdTimeLayout)),
+		Alias:   (*Alias)(&k),
+	})
+}
+
+// UnmarshalJSON is a custom method for handling datetime unmarshalling
+func (k *APIKey) UnmarshalJSON(data []byte) error {
+	type Alias APIKey
+	aux := &struct {
+		Created *string `json:"created,omitempty"`
+		*Alias
+	}{
+		Alias: (*Alias)(k),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	if created, err := time.Parse(createdTimeLayout, *aux.Created); err != nil {
+		return err
+	} else {
+		k.Created = &created
+	}
+
+	return nil
+}
+
+// GetAPIKeys returns all API keys or error on failure
+func (client *Client) GetAPIKeys() ([]APIKey, error) {
+	var out reqAPIKeys
+	if err := client.doJsonRequest("GET", "/v1/api_key", nil, &out); err != nil {
+		return nil, err
+	}
+
+	return out.APIKeys, nil
+}
+
+// GetAPIKey returns a single API key or error on failure
+func (client *Client) GetAPIKey(key string) (*APIKey, error) {
+	var out reqAPIKey
+	if err := client.doJsonRequest("GET", fmt.Sprintf("/v1/api_key/%s", key), nil, &out); err != nil {
+		return nil, err
+	}
+
+	return out.APIKey, nil
+}
+
+// CreateAPIKey creates an API key from given struct and fills the rest of its
+// fileds, or returns an error on failure
+func (client *Client) CreateAPIKey(name *string) (*APIKey, error) {
+	toPost := struct {
+		Name *string `json:"name,omitempty"`
+	}{
+		name,
+	}
+	var out reqAPIKey
+	if err := client.doJsonRequest("POST", "/v1/api_key", toPost, &out); err != nil {
+		return nil, err
+	}
+	return out.APIKey, nil
+}
+
+// UpdateAPIKey updates given API key (only Name can be updated), returns an error
+func (client *Client) UpdateAPIKey(apikey *APIKey) error {
+	out := reqAPIKey{APIKey: apikey}
+	toPost := struct {
+		Name *string `json:"name,omitempty"`
+	}{
+		apikey.Name,
+	}
+	return client.doJsonRequest("PUT", fmt.Sprintf("/v1/api_key/%s", *apikey.Key), toPost, &out)
+}
+
+// DeleteAPIKey deletes API key given by key, returns an error
+func (client *Client) DeleteAPIKey(key string) error {
+	return client.doJsonRequest("DELETE", fmt.Sprintf("/v1/api_key/%s", key), nil, nil)
+}

--- a/api_keys_test.go
+++ b/api_keys_test.go
@@ -1,0 +1,42 @@
+/*
+ * Datadog API for Go
+ *
+ * Please see the included LICENSE file for licensing information.
+ *
+ * Copyright 2019 by authors and contributors.
+ */
+
+package datadog_test
+
+import (
+	"testing"
+	"time"
+
+	"encoding/json"
+
+	"github.com/stretchr/testify/assert"
+	dd "github.com/zorkian/go-datadog-api"
+)
+
+func TestAPIKeySerialization(t *testing.T) {
+
+	raw := `
+	{
+		"created_by": "john@example.com",
+		"name": "myCoolKey",
+		"key": "3111111111111111aaaaaaaaaaaaaaaa",
+		"created": "2019-04-05 09:47:00"
+	}`
+
+	var apikey dd.APIKey
+	err := json.Unmarshal([]byte(raw), &apikey)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, *apikey.Name, "myCoolKey")
+	assert.Equal(t, *apikey.CreatedBy, "john@example.com")
+	assert.Equal(t, *apikey.Key, "3111111111111111aaaaaaaaaaaaaaaa")
+	assert.Equal(t, *apikey.Created, time.Date(2019, 4, 5, 9, 47, 0, 0, time.UTC))
+
+	// make sure that the date is correct after marshaling
+	res, _ := json.Marshal(apikey)
+	assert.Contains(t, string(res), "\"2019-04-05 09:47:00\"")
+}

--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -11,6 +11,7 @@ package datadog
 
 import (
 	"encoding/json"
+	"time"
 )
 
 // GetCreator returns the Creator field if non-nil, zero value otherwise.
@@ -724,6 +725,130 @@ func (a *AlertValueDefinition) HasUnit() bool {
 // SetUnit allocates a new a.Unit and returns the pointer to it.
 func (a *AlertValueDefinition) SetUnit(v string) {
 	a.Unit = &v
+}
+
+// GetCreated returns the Created field if non-nil, zero value otherwise.
+func (a *APIKey) GetCreated() time.Time {
+	if a == nil || a.Created == nil {
+		return time.Time{}
+	}
+	return *a.Created
+}
+
+// GetCreatedOk returns a tuple with the Created field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (a *APIKey) GetCreatedOk() (time.Time, bool) {
+	if a == nil || a.Created == nil {
+		return time.Time{}, false
+	}
+	return *a.Created, true
+}
+
+// HasCreated returns a boolean if a field has been set.
+func (a *APIKey) HasCreated() bool {
+	if a != nil && a.Created != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCreated allocates a new a.Created and returns the pointer to it.
+func (a *APIKey) SetCreated(v time.Time) {
+	a.Created = &v
+}
+
+// GetCreatedBy returns the CreatedBy field if non-nil, zero value otherwise.
+func (a *APIKey) GetCreatedBy() string {
+	if a == nil || a.CreatedBy == nil {
+		return ""
+	}
+	return *a.CreatedBy
+}
+
+// GetCreatedByOk returns a tuple with the CreatedBy field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (a *APIKey) GetCreatedByOk() (string, bool) {
+	if a == nil || a.CreatedBy == nil {
+		return "", false
+	}
+	return *a.CreatedBy, true
+}
+
+// HasCreatedBy returns a boolean if a field has been set.
+func (a *APIKey) HasCreatedBy() bool {
+	if a != nil && a.CreatedBy != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCreatedBy allocates a new a.CreatedBy and returns the pointer to it.
+func (a *APIKey) SetCreatedBy(v string) {
+	a.CreatedBy = &v
+}
+
+// GetKey returns the Key field if non-nil, zero value otherwise.
+func (a *APIKey) GetKey() string {
+	if a == nil || a.Key == nil {
+		return ""
+	}
+	return *a.Key
+}
+
+// GetKeyOk returns a tuple with the Key field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (a *APIKey) GetKeyOk() (string, bool) {
+	if a == nil || a.Key == nil {
+		return "", false
+	}
+	return *a.Key, true
+}
+
+// HasKey returns a boolean if a field has been set.
+func (a *APIKey) HasKey() bool {
+	if a != nil && a.Key != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetKey allocates a new a.Key and returns the pointer to it.
+func (a *APIKey) SetKey(v string) {
+	a.Key = &v
+}
+
+// GetName returns the Name field if non-nil, zero value otherwise.
+func (a *APIKey) GetName() string {
+	if a == nil || a.Name == nil {
+		return ""
+	}
+	return *a.Name
+}
+
+// GetNameOk returns a tuple with the Name field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (a *APIKey) GetNameOk() (string, bool) {
+	if a == nil || a.Name == nil {
+		return "", false
+	}
+	return *a.Name, true
+}
+
+// HasName returns a boolean if a field has been set.
+func (a *APIKey) HasName() bool {
+	if a != nil && a.Name != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetName allocates a new a.Name and returns the pointer to it.
+func (a *APIKey) SetName(v string) {
+	a.Name = &v
 }
 
 // GetAggregation returns the Aggregation field if non-nil, zero value otherwise.
@@ -11295,6 +11420,37 @@ func (r *Recurrence) HasUntilOccurrences() bool {
 // SetUntilOccurrences allocates a new r.UntilOccurrences and returns the pointer to it.
 func (r *Recurrence) SetUntilOccurrences(v int) {
 	r.UntilOccurrences = &v
+}
+
+// GetAPIKey returns the APIKey field if non-nil, zero value otherwise.
+func (r *reqAPIKey) GetAPIKey() APIKey {
+	if r == nil || r.APIKey == nil {
+		return APIKey{}
+	}
+	return *r.APIKey
+}
+
+// GetAPIKeyOk returns a tuple with the APIKey field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (r *reqAPIKey) GetAPIKeyOk() (APIKey, bool) {
+	if r == nil || r.APIKey == nil {
+		return APIKey{}, false
+	}
+	return *r.APIKey, true
+}
+
+// HasAPIKey returns a boolean if a field has been set.
+func (r *reqAPIKey) HasAPIKey() bool {
+	if r != nil && r.APIKey != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAPIKey allocates a new r.APIKey and returns the pointer to it.
+func (r *reqAPIKey) SetAPIKey(v APIKey) {
+	r.APIKey = &v
 }
 
 // GetComment returns the Comment field if non-nil, zero value otherwise.

--- a/integration/api_keys_test.go
+++ b/integration/api_keys_test.go
@@ -1,0 +1,120 @@
+/*
+ * Datadog API for Go
+ *
+ * Please see the included LICENSE file for licensing information.
+ *
+ * Copyright 2019 by authors and contributors.
+ */
+package integration
+
+import (
+	"testing"
+
+	"github.com/zorkian/go-datadog-api"
+)
+
+func TestAPIKeyCreateGetAndDelete(t *testing.T) {
+	keyName := "client-test-key"
+	expected, err := client.CreateAPIKey(datadog.String(keyName))
+	if err != nil {
+		t.Fatalf("Creating API key failed when it shouldn't. (%s)", err)
+	}
+	defer cleanUpAPIKey(t, *expected.Key)
+
+	if *expected.Name != keyName {
+		t.Errorf("Created key has wrong name. Got %s, want %s", *expected.Name, keyName)
+	}
+
+	// now try to fetch it freshly and compare it again
+	actual, err := client.GetAPIKey(*expected.Key)
+	if err != nil {
+		t.Fatalf("Retrieving API key failed when it shouldn't. (%s)", err)
+	}
+	assertAPIKeyEquals(t, actual, expected)
+}
+
+func TestAPIKeyUpdateName(t *testing.T) {
+	keyName := datadog.String("client-test-key")
+	newKeyName := datadog.String("client-test-key-new")
+	keyStruct, err := client.CreateAPIKey(keyName)
+	if err != nil {
+		t.Fatalf("Creating API key failed when it shouldn't. (%s)", err)
+	}
+	defer cleanUpAPIKey(t, *keyStruct.Key)
+
+	keyStruct.Name = newKeyName
+	err = client.UpdateAPIKey(keyStruct)
+	if err != nil {
+		t.Fatalf("Updating API key failed when it shouldn't. (%s)", err)
+	}
+
+	if keyStruct.Name != newKeyName {
+		t.Errorf("API key name not updated. Got %s, want %s", *keyStruct.Name, *newKeyName)
+	}
+}
+
+func TestAPIKeyGetMultipleKeys(t *testing.T) {
+	key1Name := datadog.String("client-test-1")
+	key2Name := datadog.String("client-test-2")
+	key1, err := client.CreateAPIKey(key1Name)
+	if err != nil {
+		t.Fatalf("Creating API key failed when it shouldn't. (%s)", err)
+	}
+	defer cleanUpAPIKey(t, *key1.Key)
+	key2, err := client.CreateAPIKey(key2Name)
+	if err != nil {
+		t.Fatalf("Creating API key failed when it shouldn't. (%s)", err)
+	}
+	defer cleanUpAPIKey(t, *key2.Key)
+	allKeys, err := client.GetAPIKeys()
+	if err != nil {
+		t.Fatalf("Getting all API keys failed when it shouldn't (%s)", err)
+	}
+	key1Found, key2Found := false, false
+	for _, key := range allKeys {
+		switch *key.Name {
+		case *key1Name:
+			assertAPIKeyEquals(t, &key, key1)
+			key1Found = true
+		case *key2Name:
+			assertAPIKeyEquals(t, &key, key2)
+			key2Found = true
+		}
+	}
+	if key1Found == false {
+		t.Errorf("Key 1 not found while getting multiple keys.")
+	}
+	if key2Found == false {
+		t.Errorf("Key 2 not found while getting multiple keys.")
+	}
+}
+
+func assertAPIKeyEquals(t *testing.T, actual, expected *datadog.APIKey) {
+	if *actual.Created != *expected.Created {
+		t.Errorf("APIKey created does not match: %s != %s", *actual.Created, *expected.Created)
+	}
+	if *actual.CreatedBy != *expected.CreatedBy {
+		t.Errorf("APIKey created_by does not match: %s != %s", *actual.CreatedBy, *expected.CreatedBy)
+	}
+	if *actual.Key != *expected.Key {
+		t.Errorf("APIKey key does not match: %s != %s", *actual.Key, *expected.Key)
+	}
+	if *actual.Name != *expected.Name {
+		t.Errorf("APIKey name does not match: %s != %s", *actual.Name, *expected.Name)
+	}
+}
+
+func cleanUpAPIKey(t *testing.T, key string) {
+	if err := client.DeleteAPIKey(key); err != nil {
+		t.Fatalf("Deleting api key failed when it shouldn't. Manual cleanup needed. (%s)", err)
+	}
+
+	deletedKey, err := client.GetAPIKey(key)
+	if deletedKey != nil {
+		t.Fatal("API key hasn't been deleted when it should have been. Manual cleanup needed.")
+	}
+
+	if err == nil {
+		t.Fatal("Fetching deleted API key didn't lead to an error. Manual cleanup needed.")
+	}
+}


### PR DESCRIPTION
This PR represents the first part of what needs to be implemented to allow implementation of Terraform Datadog Provider API/APP keys related functionality as requested in https://github.com/terraform-providers/terraform-provider-datadog/issues/90