### PR TITLE
Fix invocation of go vet in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 TEST?=$$(go list ./... | grep -v '/go-datadog-api/vendor/')
-VETARGS?=-asmdecl -atomic -bool -buildtags -copylocks -methods -nilfunc -printf -rangeloops -shift -structtags -unsafeptr
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 
 default: test fmt
@@ -26,11 +25,8 @@ fmt:
 # vet runs the Go source code static analysis tool `vet` to find
 # any common errors.
 vet:
-	@go tool vet 2>/dev/null ; if [ $$? -eq 3 ]; then \
-		go get golang.org/x/tools/cmd/vet; \
-	fi
-	@echo "go tool vet $(VETARGS)"
-	@go tool vet $(VETARGS) $$(ls -d */ | grep -v vendor) ; if [ $$? -eq 1 ]; then \
+	@echo "go vet"
+	@go vet; if [ $$? -ne 0 ]; then \
 		echo ""; \
 		echo "Vet found suspicious constructs. Please check the reported constructs"; \
 		echo "and fix them if necessary before submitting the code for review."; \


### PR DESCRIPTION
go tool vet is not supported since go 1.12, we should use go vet instead. This
fixes the flags used, and all call it for the base package.