### PR TITLE
Add functionality to manipulate application keys

### DIFF
--- a/app_keys.go
+++ b/app_keys.go
@@ -1,0 +1,83 @@
+/*
+ * Datadog API for Go
+ *
+ * Please see the included LICENSE file for licensing information.
+ *
+ * Copyright 2019 by authors and contributors.
+ */
+
+package datadog
+
+import (
+	"fmt"
+)
+
+// APPKey represents an APP key
+type APPKey struct {
+	Owner *string `json:"owner,omitempty"`
+	Name  *string `json:"name,omitemtpy"`
+	Hash  *string `json:"hash,omitempty"`
+}
+
+// reqAPPKeys retrieves a slice of all APPKeys.
+type reqAPPKeys struct {
+	APPKeys []APPKey `json:"application_keys,omitempty"`
+}
+
+// reqAPPKey is similar to reqAPPKeys, but used for values returned by
+// /v1/application_key/<somekey> which contain one object (not list) "application_key"
+// (not "application_keys") containing the found key
+type reqAPPKey struct {
+	APPKey *APPKey `json:"application_key"`
+}
+
+// GetAPPKeys returns all APP keys or error on failure
+func (client *Client) GetAPPKeys() ([]APPKey, error) {
+	var out reqAPPKeys
+	if err := client.doJsonRequest("GET", "/v1/application_key", nil, &out); err != nil {
+		return nil, err
+	}
+
+	return out.APPKeys, nil
+}
+
+// GetAPPKey returns a single APP key or error on failure
+func (client *Client) GetAPPKey(hash string) (*APPKey, error) {
+	var out reqAPPKey
+	if err := client.doJsonRequest("GET", fmt.Sprintf("/v1/application_key/%s", hash), nil, &out); err != nil {
+		return nil, err
+	}
+
+	return out.APPKey, nil
+}
+
+// CreateAPPKey creates an APP key from given name and fills the rest of its
+// fields, or returns an error on failure
+func (client *Client) CreateAPPKey(name string) (*APPKey, error) {
+	toPost := struct {
+		Name *string `json:"name,omitempty"`
+	}{
+		&name,
+	}
+	var out reqAPPKey
+	if err := client.doJsonRequest("POST", "/v1/application_key", toPost, &out); err != nil {
+		return nil, err
+	}
+	return out.APPKey, nil
+}
+
+// UpdateAPPKey updates given APP key (only Name can be updated), returns an error
+func (client *Client) UpdateAPPKey(appkey *APPKey) error {
+	out := reqAPPKey{APPKey: appkey}
+	toPost := struct {
+		Name *string `json:"name,omitempty"`
+	}{
+		appkey.Name,
+	}
+	return client.doJsonRequest("PUT", fmt.Sprintf("/v1/application_key/%s", *appkey.Hash), toPost, &out)
+}
+
+// DeleteAPPKey deletes APP key given by hash, returns an error
+func (client *Client) DeleteAPPKey(hash string) error {
+	return client.doJsonRequest("DELETE", fmt.Sprintf("/v1/application_key/%s", hash), nil, nil)
+}

--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -1161,6 +1161,99 @@ func (a *ApmOrLogQuerySearch) SetQuery(v string) {
 	a.Query = &v
 }
 
+// GetHash returns the Hash field if non-nil, zero value otherwise.
+func (a *APPKey) GetHash() string {
+	if a == nil || a.Hash == nil {
+		return ""
+	}
+	return *a.Hash
+}
+
+// GetHashOk returns a tuple with the Hash field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (a *APPKey) GetHashOk() (string, bool) {
+	if a == nil || a.Hash == nil {
+		return "", false
+	}
+	return *a.Hash, true
+}
+
+// HasHash returns a boolean if a field has been set.
+func (a *APPKey) HasHash() bool {
+	if a != nil && a.Hash != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetHash allocates a new a.Hash and returns the pointer to it.
+func (a *APPKey) SetHash(v string) {
+	a.Hash = &v
+}
+
+// GetName returns the Name field if non-nil, zero value otherwise.
+func (a *APPKey) GetName() string {
+	if a == nil || a.Name == nil {
+		return ""
+	}
+	return *a.Name
+}
+
+// GetNameOk returns a tuple with the Name field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (a *APPKey) GetNameOk() (string, bool) {
+	if a == nil || a.Name == nil {
+		return "", false
+	}
+	return *a.Name, true
+}
+
+// HasName returns a boolean if a field has been set.
+func (a *APPKey) HasName() bool {
+	if a != nil && a.Name != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetName allocates a new a.Name and returns the pointer to it.
+func (a *APPKey) SetName(v string) {
+	a.Name = &v
+}
+
+// GetOwner returns the Owner field if non-nil, zero value otherwise.
+func (a *APPKey) GetOwner() string {
+	if a == nil || a.Owner == nil {
+		return ""
+	}
+	return *a.Owner
+}
+
+// GetOwnerOk returns a tuple with the Owner field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (a *APPKey) GetOwnerOk() (string, bool) {
+	if a == nil || a.Owner == nil {
+		return "", false
+	}
+	return *a.Owner, true
+}
+
+// HasOwner returns a boolean if a field has been set.
+func (a *APPKey) HasOwner() bool {
+	if a != nil && a.Owner != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetOwner allocates a new a.Owner and returns the pointer to it.
+func (a *APPKey) SetOwner(v string) {
+	a.Owner = &v
+}
+
 // GetAuthorHandle returns the AuthorHandle field if non-nil, zero value otherwise.
 func (b *Board) GetAuthorHandle() string {
 	if b == nil || b.AuthorHandle == nil {
@@ -11451,6 +11544,37 @@ func (r *reqAPIKey) HasAPIKey() bool {
 // SetAPIKey allocates a new r.APIKey and returns the pointer to it.
 func (r *reqAPIKey) SetAPIKey(v APIKey) {
 	r.APIKey = &v
+}
+
+// GetAPPKey returns the APPKey field if non-nil, zero value otherwise.
+func (r *reqAPPKey) GetAPPKey() APPKey {
+	if r == nil || r.APPKey == nil {
+		return APPKey{}
+	}
+	return *r.APPKey
+}
+
+// GetAPPKeyOk returns a tuple with the APPKey field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (r *reqAPPKey) GetAPPKeyOk() (APPKey, bool) {
+	if r == nil || r.APPKey == nil {
+		return APPKey{}, false
+	}
+	return *r.APPKey, true
+}
+
+// HasAPPKey returns a boolean if a field has been set.
+func (r *reqAPPKey) HasAPPKey() bool {
+	if r != nil && r.APPKey != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAPPKey allocates a new r.APPKey and returns the pointer to it.
+func (r *reqAPPKey) SetAPPKey(v APPKey) {
+	r.APPKey = &v
 }
 
 // GetComment returns the Comment field if non-nil, zero value otherwise.

--- a/integration/app_keys_test.go
+++ b/integration/app_keys_test.go
@@ -1,0 +1,117 @@
+/*
+ * Datadog API for Go
+ *
+ * Please see the included LICENSE file for licensing information.
+ *
+ * Copyright 2019 by authors and contributors.
+ */
+package integration
+
+import (
+	"testing"
+
+	"github.com/zorkian/go-datadog-api"
+)
+
+func TestAPPKeyCreateGetAndDelete(t *testing.T) {
+	keyName := "client-test-key"
+	expected, err := client.CreateAPPKey(keyName)
+	if err != nil {
+		t.Fatalf("Creating APP key failed when it shouldn't. (%s)", err)
+	}
+	defer cleanUpAPPKey(t, *expected.Hash)
+
+	if *expected.Name != keyName {
+		t.Errorf("Created key has wrong name. Got %s, want %s", *expected.Name, keyName)
+	}
+
+	// now try to fetch it freshly and compare it again
+	actual, err := client.GetAPPKey(*expected.Hash)
+	if err != nil {
+		t.Fatalf("Retrieving APP key failed when it shouldn't. (%s)", err)
+	}
+	assertAPPKeyEquals(t, actual, expected)
+}
+
+func TestAPPKeyUpdateName(t *testing.T) {
+	keyName := "client-test-key"
+	newKeyName := "client-test-key-new"
+	keyStruct, err := client.CreateAPPKey(keyName)
+	if err != nil {
+		t.Fatalf("Creating APP key failed when it shouldn't. (%s)", err)
+	}
+	defer cleanUpAPPKey(t, *keyStruct.Hash)
+
+	*keyStruct.Name = newKeyName
+	err = client.UpdateAPPKey(keyStruct)
+	if err != nil {
+		t.Fatalf("Updating APP key failed when it shouldn't. (%s)", err)
+	}
+
+	if *keyStruct.Name != newKeyName {
+		t.Errorf("APP key name not updated. Got %s, want %s", *keyStruct.Name, newKeyName)
+	}
+}
+
+func TestAPPKeyGetMultipleKeys(t *testing.T) {
+	key1Name := "client-test-1"
+	key2Name := "client-test-2"
+	key1, err := client.CreateAPPKey(key1Name)
+	if err != nil {
+		t.Fatalf("Creating APP key failed when it shouldn't. (%s)", err)
+	}
+	defer cleanUpAPPKey(t, *key1.Hash)
+	key2, err := client.CreateAPPKey(key2Name)
+	if err != nil {
+		t.Fatalf("Creating APP key failed when it shouldn't. (%s)", err)
+	}
+	defer cleanUpAPPKey(t, *key2.Hash)
+	allKeys, err := client.GetAPPKeys()
+	if err != nil {
+		t.Fatalf("Getting all APP keys failed when it shouldn't (%s)", err)
+	}
+	key1Found, key2Found := false, false
+	for _, key := range allKeys {
+		switch *key.Name {
+		case key1Name:
+			assertAPPKeyEquals(t, &key, key1)
+			key1Found = true
+		case key2Name:
+			assertAPPKeyEquals(t, &key, key2)
+			key2Found = true
+		}
+	}
+	if key1Found == false {
+		t.Errorf("Key 1 not found while getting multiple keys.")
+	}
+	if key2Found == false {
+		t.Errorf("Key 2 not found while getting multiple keys.")
+	}
+}
+
+func assertAPPKeyEquals(t *testing.T, actual, expected *datadog.APPKey) {
+	if *actual.Owner != *expected.Owner {
+		t.Errorf("APPKey owner does not match: %s != %s", *actual.Owner, *expected.Owner)
+	}
+	if *actual.Hash != *expected.Hash {
+		t.Errorf("APPKey hash does not match: %s != %s", *actual.Hash, *expected.Hash)
+	}
+	if *actual.Name != *expected.Name {
+		t.Errorf("APPKey name does not match: %s != %s", *actual.Name, *expected.Name)
+	}
+}
+
+func cleanUpAPPKey(t *testing.T, hash string) {
+	if err := client.DeleteAPPKey(hash); err != nil {
+		t.Fatalf("Deleting app key failed when it shouldn't. Manual cleanup needed. (%s)", err)
+	}
+
+	deletedKey, err := client.GetAPPKey(hash)
+	if deletedKey != nil {
+		t.Fatal("APP key hasn't been deleted when it should have been. Manual cleanup needed.")
+	}
+
+	if err == nil {
+		t.Fatal("Fetching deleted APP key didn't lead to an error. Manual cleanup needed.")
+	}
+}


### PR DESCRIPTION
Do not merge yet; the Update method doesn't work as there seems to be bug in the API preventing doing the PUT request (it's known and being worked on IIUC). Once it's fixed, this PR should be ready to go.

This is the next piece required to be able to implement https://github.com/terraform-providers/terraform-provider-datadog/issues/90 in the TF DD provider.