### PR TITLE
Add CustomBgColor to ScreenWidgets

### DIFF
--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -2711,6 +2711,37 @@ func (c *ConditionalFormat) SetComparator(v string) {
 	c.Comparator = &v
 }
 
+// GetCustomBgColor returns the CustomBgColor field if non-nil, zero value otherwise.
+func (c *ConditionalFormat) GetCustomBgColor() string {
+	if c == nil || c.CustomBgColor == nil {
+		return ""
+	}
+	return *c.CustomBgColor
+}
+
+// GetCustomBgColorOk returns a tuple with the CustomBgColor field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (c *ConditionalFormat) GetCustomBgColorOk() (string, bool) {
+	if c == nil || c.CustomBgColor == nil {
+		return "", false
+	}
+	return *c.CustomBgColor, true
+}
+
+// HasCustomBgColor returns a boolean if a field has been set.
+func (c *ConditionalFormat) HasCustomBgColor() bool {
+	if c != nil && c.CustomBgColor != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCustomBgColor allocates a new c.CustomBgColor and returns the pointer to it.
+func (c *ConditionalFormat) SetCustomBgColor(v string) {
+	c.CustomBgColor = &v
+}
+
 // GetImageURL returns the ImageURL field if non-nil, zero value otherwise.
 func (c *ConditionalFormat) GetImageURL() string {
 	if c == nil || c.ImageURL == nil {

--- a/integration/screen_widgets_test.go
+++ b/integration/screen_widgets_test.go
@@ -88,9 +88,10 @@ func TestWidgets(t *testing.T) {
 					},
 					ConditionalFormats: []datadog.ConditionalFormat{
 						{
-							Comparator: datadog.String(">="),
-							Value:      datadog.String("1"),
-							Palette:    datadog.String("white_on_red"),
+							Comparator:    datadog.String(">="),
+							CustomBgColor: datadog.String("#205081"),
+							Value:         datadog.String("1"),
+							Palette:       datadog.String("white_on_red"),
 						}},
 					Aggregator: datadog.String("max"),
 				}},

--- a/screen_widgets.go
+++ b/screen_widgets.go
@@ -86,12 +86,13 @@ type TileDefMetadata struct {
 }
 
 type ConditionalFormat struct {
-	Color      *string `json:"color,omitempty"`
-	Palette    *string `json:"palette,omitempty"`
-	Comparator *string `json:"comparator,omitempty"`
-	Invert     *bool   `json:"invert,omitempty"`
-	Value      *string `json:"value,omitempty"`
-	ImageURL   *string `json:"image_url,omitempty"`
+	Color         *string `json:"color,omitempty"`
+	Palette       *string `json:"palette,omitempty"`
+	Comparator    *string `json:"comparator,omitempty"`
+	Invert        *bool   `json:"invert,omitempty"`
+	CustomBgColor *string `json:"custom_bg_color,omitempty"`
+	Value         *string `json:"value,omitempty"`
+	ImageURL      *string `json:"image_url,omitempty"`
 }
 
 type TileDefRequestStyle struct {


### PR DESCRIPTION
Related to https://github.com/terraform-providers/terraform-provider-datadog/pull/189.

This PR adds the possibility to add a `custom_bg_color` to a screen in Datadog.