### PR TITLE
Add monitor_id in Synthetics test config

### DIFF
--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -14739,6 +14739,37 @@ func (s *SyntheticsTest) SetModifiedBy(v SyntheticsUser) {
 	s.ModifiedBy = &v
 }
 
+// GetMonitorId returns the MonitorId field if non-nil, zero value otherwise.
+func (s *SyntheticsTest) GetMonitorId() int {
+	if s == nil || s.MonitorId == nil {
+		return 0
+	}
+	return *s.MonitorId
+}
+
+// GetMonitorIdOk returns a tuple with the MonitorId field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (s *SyntheticsTest) GetMonitorIdOk() (int, bool) {
+	if s == nil || s.MonitorId == nil {
+		return 0, false
+	}
+	return *s.MonitorId, true
+}
+
+// HasMonitorId returns a boolean if a field has been set.
+func (s *SyntheticsTest) HasMonitorId() bool {
+	if s != nil && s.MonitorId != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetMonitorId allocates a new s.MonitorId and returns the pointer to it.
+func (s *SyntheticsTest) SetMonitorId(v int) {
+	s.MonitorId = &v
+}
+
 // GetMonitorStatus returns the MonitorStatus field if non-nil, zero value otherwise.
 func (s *SyntheticsTest) GetMonitorStatus() string {
 	if s == nil || s.MonitorStatus == nil {

--- a/synthetics.go
+++ b/synthetics.go
@@ -8,6 +8,7 @@ import (
 // SyntheticsTest represents a synthetics test, either api or browser
 type SyntheticsTest struct {
 	PublicId      *string            `json:"public_id,omitempty"`
+	MonitorId     *int               `json:"monitor_id,omitempty"`
 	Name          *string            `json:"name,omitempty"`
 	Type          *string            `json:"type,omitempty"`
 	Tags          []string           `json:"tags"`

--- a/synthetics_test.go
+++ b/synthetics_test.go
@@ -60,6 +60,11 @@ func TestGetSyntheticsTestApi(t *testing.T) {
 		t.Fatalf("expect public_id %s. Got %s", expectedPublicId, publicId)
 	}
 
+	expectedMonitorId := 666
+	if monitorId := c.GetMonitorId(); monitorId != expectedMonitorId {
+		t.Fatalf("expect monitor_id %d. Got %d", expectedMonitorId, monitorId)
+	}
+
 	expectedName := "Check on example.com"
 	if name := c.GetName(); name != expectedName {
 		t.Fatalf("expect name %s. Got %s", expectedName, name)
@@ -191,6 +196,11 @@ func TestGetSyntheticsTestBrowser(t *testing.T) {
 	expectedPublicId := "xxx-xxx-xxx"
 	if publicId := c.GetPublicId(); publicId != expectedPublicId {
 		t.Fatalf("expect public_id %s. Got %s", expectedPublicId, publicId)
+	}
+
+	expectedMonitorId := 666
+	if monitorId := c.GetMonitorId(); monitorId != expectedMonitorId {
+		t.Fatalf("expect monitor_id %d. Got %d", expectedMonitorId, monitorId)
 	}
 
 	expectedName := "Check on example.com"

--- a/tests/fixtures/synthetics/tests/get_test_api.json
+++ b/tests/fixtures/synthetics/tests/get_test_api.json
@@ -1,5 +1,6 @@
 {
   "public_id": "xxx-xxx-xxx",
+  "monitor_id": 666,
   "tags": [
     "example_tag"
   ],

--- a/tests/fixtures/synthetics/tests/get_test_browser.json
+++ b/tests/fixtures/synthetics/tests/get_test_browser.json
@@ -1,5 +1,6 @@
 {
   "public_id": "xxx-xxx-xxx",
+  "monitor_id": 666,
   "tags": [
     "example_tag"
   ],


### PR DESCRIPTION
The Synthetics API now returns the monitor ID along with the test config.
This especially allows to use a Synthetics test in a composite monitor.