### PR TITLE
As documentation states, PUT has to be used to create the PD integration

### DIFF
--- a/integrations.go
+++ b/integrations.go
@@ -44,7 +44,7 @@ type IntegrationPDRequest struct {
 // Use this if you want to setup the integration for the first time
 // or to add more services/schedules.
 func (client *Client) CreateIntegrationPD(pdIntegration *IntegrationPDRequest) error {
-	return client.doJsonRequest("POST", "/v1/integration/pagerduty", pdIntegration, nil)
+	return client.doJsonRequest("PUT", "/v1/integration/pagerduty", pdIntegration, nil)
 }
 
 // UpdateIntegrationPD updates the PagerDuty Integration.


### PR DESCRIPTION
Using POST (the previous state) makes the operation fail sometimes with 405 error, see e.g. https://github.com/terraform-providers/terraform-provider-datadog/issues/160

See https://docs.datadoghq.com/api/?lang=bash#create-a-pagerduty-integration for documentation of this endpoint - PUT is really the suggested verb to use to create the integration.