### PR TITLE
[dashboard] Add support for log, apm and process query in legacy API

### DIFF
--- a/dashboards.go
+++ b/dashboards.go
@@ -37,6 +37,39 @@ type GraphDefinitionRequest struct {
 	OrderBy        *string                            `json:"order_by,omitempty"`
 	ExtraCol       *string                            `json:"extra_col,omitempty"`
 	Metadata       map[string]GraphDefinitionMetadata `json:"metadata,omitempty"`
+
+	// For APM and log query
+	LogQuery *GraphApmOrLogQuery `json:"log_query,omitempty"`
+}
+
+// GraphApmOrLogQuery represents an APM or a Log query
+type GraphApmOrLogQuery struct {
+	Index   *string                     `json:"index"`
+	Compute *GraphApmOrLogQueryCompute  `json:"compute"`
+	Search  *GraphApmOrLogQuerySearch   `json:"search,omitempty"`
+	GroupBy []GraphApmOrLogQueryGroupBy `json:"groupBy,omitempty"`
+}
+
+type GraphApmOrLogQueryCompute struct {
+	Aggregation *string `json:"aggregation"`
+	Facet       *string `json:"facet,omitempty"`
+	Interval    *int    `json:"interval,omitempty"`
+}
+
+type GraphApmOrLogQuerySearch struct {
+	Query *string `json:"query"`
+}
+
+type GraphApmOrLogQueryGroupBy struct {
+	Facet *string                        `json:"facet"`
+	Limit *int                           `json:"limit,omitempty"`
+	Sort  *GraphApmOrLogQueryGroupBySort `json:"sort,omitempty"`
+}
+
+type GraphApmOrLogQueryGroupBySort struct {
+	Aggregation *string `json:"aggregation"`
+	Order       *string `json:"order"`
+	Facet       *string `json:"facet,omitempty"`
 }
 
 type GraphDefinitionMetadata TileDefMetadata

--- a/dashboards.go
+++ b/dashboards.go
@@ -37,9 +37,10 @@ type GraphDefinitionRequest struct {
 	ExtraCol       *string                            `json:"extra_col,omitempty"`
 	Metadata       map[string]GraphDefinitionMetadata `json:"metadata,omitempty"`
 
+	// A Graph can only have one of these types of query.
 	Query        *string             `json:"q,omitempty"`
 	LogQuery     *GraphApmOrLogQuery `json:"log_query,omitempty"`
-	APMQuery     *GraphApmOrLogQuery `json:"apm_query,omitempty"`
+	ApmQuery     *GraphApmOrLogQuery `json:"apm_query,omitempty"`
 	ProcessQuery *GraphProcessQuery  `json:"process_query,omitempty"`
 }
 

--- a/dashboards.go
+++ b/dashboards.go
@@ -22,7 +22,6 @@ type GraphDefinitionRequestStyle struct {
 
 // GraphDefinitionRequest represents the requests passed into each graph.
 type GraphDefinitionRequest struct {
-	Query              *string                      `json:"q,omitempty"`
 	Stacked            *bool                        `json:"stacked,omitempty"`
 	Aggregator         *string                      `json:"aggregator,omitempty"`
 	ConditionalFormats []DashboardConditionalFormat `json:"conditional_formats,omitempty"`
@@ -38,8 +37,10 @@ type GraphDefinitionRequest struct {
 	ExtraCol       *string                            `json:"extra_col,omitempty"`
 	Metadata       map[string]GraphDefinitionMetadata `json:"metadata,omitempty"`
 
-	// For APM and log query
-	LogQuery *GraphApmOrLogQuery `json:"log_query,omitempty"`
+	Query        *string             `json:"q,omitempty"`
+	LogQuery     *GraphApmOrLogQuery `json:"log_query,omitempty"`
+	APMQuery     *GraphApmOrLogQuery `json:"apm_query,omitempty"`
+	ProcessQuery *GraphProcessQuery  `json:"process_query,omitempty"`
 }
 
 // GraphApmOrLogQuery represents an APM or a Log query
@@ -70,6 +71,13 @@ type GraphApmOrLogQueryGroupBySort struct {
 	Aggregation *string `json:"aggregation"`
 	Order       *string `json:"order"`
 	Facet       *string `json:"facet,omitempty"`
+}
+
+type GraphProcessQuery struct {
+	Metric   *string  `json:"metric"`
+	SearchBy *string  `json:"search_by,omitempty"`
+	FilterBy []string `json:"filter_by,omitempty"`
+	Limit    *int     `json:"limit,omitempty"`
 }
 
 type GraphDefinitionMetadata TileDefMetadata

--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -6989,35 +6989,35 @@ func (g *GraphDefinitionRequest) SetAggregator(v string) {
 	g.Aggregator = &v
 }
 
-// GetAPMQuery returns the APMQuery field if non-nil, zero value otherwise.
-func (g *GraphDefinitionRequest) GetAPMQuery() GraphApmOrLogQuery {
-	if g == nil || g.APMQuery == nil {
+// GetApmQuery returns the ApmQuery field if non-nil, zero value otherwise.
+func (g *GraphDefinitionRequest) GetApmQuery() GraphApmOrLogQuery {
+	if g == nil || g.ApmQuery == nil {
 		return GraphApmOrLogQuery{}
 	}
-	return *g.APMQuery
+	return *g.ApmQuery
 }
 
-// GetAPMQueryOk returns a tuple with the APMQuery field if it's non-nil, zero value otherwise
+// GetApmQueryOk returns a tuple with the ApmQuery field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (g *GraphDefinitionRequest) GetAPMQueryOk() (GraphApmOrLogQuery, bool) {
-	if g == nil || g.APMQuery == nil {
+func (g *GraphDefinitionRequest) GetApmQueryOk() (GraphApmOrLogQuery, bool) {
+	if g == nil || g.ApmQuery == nil {
 		return GraphApmOrLogQuery{}, false
 	}
-	return *g.APMQuery, true
+	return *g.ApmQuery, true
 }
 
-// HasAPMQuery returns a boolean if a field has been set.
-func (g *GraphDefinitionRequest) HasAPMQuery() bool {
-	if g != nil && g.APMQuery != nil {
+// HasApmQuery returns a boolean if a field has been set.
+func (g *GraphDefinitionRequest) HasApmQuery() bool {
+	if g != nil && g.ApmQuery != nil {
 		return true
 	}
 
 	return false
 }
 
-// SetAPMQuery allocates a new g.APMQuery and returns the pointer to it.
-func (g *GraphDefinitionRequest) SetAPMQuery(v GraphApmOrLogQuery) {
-	g.APMQuery = &v
+// SetApmQuery allocates a new g.ApmQuery and returns the pointer to it.
+func (g *GraphDefinitionRequest) SetApmQuery(v GraphApmOrLogQuery) {
+	g.ApmQuery = &v
 }
 
 // GetChangeType returns the ChangeType field if non-nil, zero value otherwise.
@@ -18025,35 +18025,35 @@ func (t *TileDefRequest) SetAggregator(v string) {
 	t.Aggregator = &v
 }
 
-// GetAPMQuery returns the APMQuery field if non-nil, zero value otherwise.
-func (t *TileDefRequest) GetAPMQuery() TileDefApmOrLogQuery {
-	if t == nil || t.APMQuery == nil {
+// GetApmQuery returns the ApmQuery field if non-nil, zero value otherwise.
+func (t *TileDefRequest) GetApmQuery() TileDefApmOrLogQuery {
+	if t == nil || t.ApmQuery == nil {
 		return TileDefApmOrLogQuery{}
 	}
-	return *t.APMQuery
+	return *t.ApmQuery
 }
 
-// GetAPMQueryOk returns a tuple with the APMQuery field if it's non-nil, zero value otherwise
+// GetApmQueryOk returns a tuple with the ApmQuery field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (t *TileDefRequest) GetAPMQueryOk() (TileDefApmOrLogQuery, bool) {
-	if t == nil || t.APMQuery == nil {
+func (t *TileDefRequest) GetApmQueryOk() (TileDefApmOrLogQuery, bool) {
+	if t == nil || t.ApmQuery == nil {
 		return TileDefApmOrLogQuery{}, false
 	}
-	return *t.APMQuery, true
+	return *t.ApmQuery, true
 }
 
-// HasAPMQuery returns a boolean if a field has been set.
-func (t *TileDefRequest) HasAPMQuery() bool {
-	if t != nil && t.APMQuery != nil {
+// HasApmQuery returns a boolean if a field has been set.
+func (t *TileDefRequest) HasApmQuery() bool {
+	if t != nil && t.ApmQuery != nil {
 		return true
 	}
 
 	return false
 }
 
-// SetAPMQuery allocates a new t.APMQuery and returns the pointer to it.
-func (t *TileDefRequest) SetAPMQuery(v TileDefApmOrLogQuery) {
-	t.APMQuery = &v
+// SetApmQuery allocates a new t.ApmQuery and returns the pointer to it.
+func (t *TileDefRequest) SetApmQuery(v TileDefApmOrLogQuery) {
+	t.ApmQuery = &v
 }
 
 // GetChangeType returns the ChangeType field if non-nil, zero value otherwise.

--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -6989,6 +6989,37 @@ func (g *GraphDefinitionRequest) SetAggregator(v string) {
 	g.Aggregator = &v
 }
 
+// GetAPMQuery returns the APMQuery field if non-nil, zero value otherwise.
+func (g *GraphDefinitionRequest) GetAPMQuery() GraphApmOrLogQuery {
+	if g == nil || g.APMQuery == nil {
+		return GraphApmOrLogQuery{}
+	}
+	return *g.APMQuery
+}
+
+// GetAPMQueryOk returns a tuple with the APMQuery field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (g *GraphDefinitionRequest) GetAPMQueryOk() (GraphApmOrLogQuery, bool) {
+	if g == nil || g.APMQuery == nil {
+		return GraphApmOrLogQuery{}, false
+	}
+	return *g.APMQuery, true
+}
+
+// HasAPMQuery returns a boolean if a field has been set.
+func (g *GraphDefinitionRequest) HasAPMQuery() bool {
+	if g != nil && g.APMQuery != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAPMQuery allocates a new g.APMQuery and returns the pointer to it.
+func (g *GraphDefinitionRequest) SetAPMQuery(v GraphApmOrLogQuery) {
+	g.APMQuery = &v
+}
+
 // GetChangeType returns the ChangeType field if non-nil, zero value otherwise.
 func (g *GraphDefinitionRequest) GetChangeType() string {
 	if g == nil || g.ChangeType == nil {
@@ -7204,6 +7235,37 @@ func (g *GraphDefinitionRequest) HasOrderDirection() bool {
 // SetOrderDirection allocates a new g.OrderDirection and returns the pointer to it.
 func (g *GraphDefinitionRequest) SetOrderDirection(v string) {
 	g.OrderDirection = &v
+}
+
+// GetProcessQuery returns the ProcessQuery field if non-nil, zero value otherwise.
+func (g *GraphDefinitionRequest) GetProcessQuery() GraphProcessQuery {
+	if g == nil || g.ProcessQuery == nil {
+		return GraphProcessQuery{}
+	}
+	return *g.ProcessQuery
+}
+
+// GetProcessQueryOk returns a tuple with the ProcessQuery field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (g *GraphDefinitionRequest) GetProcessQueryOk() (GraphProcessQuery, bool) {
+	if g == nil || g.ProcessQuery == nil {
+		return GraphProcessQuery{}, false
+	}
+	return *g.ProcessQuery, true
+}
+
+// HasProcessQuery returns a boolean if a field has been set.
+func (g *GraphDefinitionRequest) HasProcessQuery() bool {
+	if g != nil && g.ProcessQuery != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetProcessQuery allocates a new g.ProcessQuery and returns the pointer to it.
+func (g *GraphDefinitionRequest) SetProcessQuery(v GraphProcessQuery) {
+	g.ProcessQuery = &v
 }
 
 // GetQuery returns the Query field if non-nil, zero value otherwise.
@@ -7452,6 +7514,99 @@ func (g *GraphEvent) HasQuery() bool {
 // SetQuery allocates a new g.Query and returns the pointer to it.
 func (g *GraphEvent) SetQuery(v string) {
 	g.Query = &v
+}
+
+// GetLimit returns the Limit field if non-nil, zero value otherwise.
+func (g *GraphProcessQuery) GetLimit() int {
+	if g == nil || g.Limit == nil {
+		return 0
+	}
+	return *g.Limit
+}
+
+// GetLimitOk returns a tuple with the Limit field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (g *GraphProcessQuery) GetLimitOk() (int, bool) {
+	if g == nil || g.Limit == nil {
+		return 0, false
+	}
+	return *g.Limit, true
+}
+
+// HasLimit returns a boolean if a field has been set.
+func (g *GraphProcessQuery) HasLimit() bool {
+	if g != nil && g.Limit != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetLimit allocates a new g.Limit and returns the pointer to it.
+func (g *GraphProcessQuery) SetLimit(v int) {
+	g.Limit = &v
+}
+
+// GetMetric returns the Metric field if non-nil, zero value otherwise.
+func (g *GraphProcessQuery) GetMetric() string {
+	if g == nil || g.Metric == nil {
+		return ""
+	}
+	return *g.Metric
+}
+
+// GetMetricOk returns a tuple with the Metric field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (g *GraphProcessQuery) GetMetricOk() (string, bool) {
+	if g == nil || g.Metric == nil {
+		return "", false
+	}
+	return *g.Metric, true
+}
+
+// HasMetric returns a boolean if a field has been set.
+func (g *GraphProcessQuery) HasMetric() bool {
+	if g != nil && g.Metric != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetMetric allocates a new g.Metric and returns the pointer to it.
+func (g *GraphProcessQuery) SetMetric(v string) {
+	g.Metric = &v
+}
+
+// GetSearchBy returns the SearchBy field if non-nil, zero value otherwise.
+func (g *GraphProcessQuery) GetSearchBy() string {
+	if g == nil || g.SearchBy == nil {
+		return ""
+	}
+	return *g.SearchBy
+}
+
+// GetSearchByOk returns a tuple with the SearchBy field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (g *GraphProcessQuery) GetSearchByOk() (string, bool) {
+	if g == nil || g.SearchBy == nil {
+		return "", false
+	}
+	return *g.SearchBy, true
+}
+
+// HasSearchBy returns a boolean if a field has been set.
+func (g *GraphProcessQuery) HasSearchBy() bool {
+	if g != nil && g.SearchBy != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSearchBy allocates a new g.SearchBy and returns the pointer to it.
+func (g *GraphProcessQuery) SetSearchBy(v string) {
+	g.SearchBy = &v
 }
 
 // GetLastNoDataTs returns the LastNoDataTs field if non-nil, zero value otherwise.
@@ -17746,6 +17901,99 @@ func (t *TileDefMetadata) SetAlias(v string) {
 	t.Alias = &v
 }
 
+// GetLimit returns the Limit field if non-nil, zero value otherwise.
+func (t *TileDefProcessQuery) GetLimit() int {
+	if t == nil || t.Limit == nil {
+		return 0
+	}
+	return *t.Limit
+}
+
+// GetLimitOk returns a tuple with the Limit field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefProcessQuery) GetLimitOk() (int, bool) {
+	if t == nil || t.Limit == nil {
+		return 0, false
+	}
+	return *t.Limit, true
+}
+
+// HasLimit returns a boolean if a field has been set.
+func (t *TileDefProcessQuery) HasLimit() bool {
+	if t != nil && t.Limit != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetLimit allocates a new t.Limit and returns the pointer to it.
+func (t *TileDefProcessQuery) SetLimit(v int) {
+	t.Limit = &v
+}
+
+// GetMetric returns the Metric field if non-nil, zero value otherwise.
+func (t *TileDefProcessQuery) GetMetric() string {
+	if t == nil || t.Metric == nil {
+		return ""
+	}
+	return *t.Metric
+}
+
+// GetMetricOk returns a tuple with the Metric field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefProcessQuery) GetMetricOk() (string, bool) {
+	if t == nil || t.Metric == nil {
+		return "", false
+	}
+	return *t.Metric, true
+}
+
+// HasMetric returns a boolean if a field has been set.
+func (t *TileDefProcessQuery) HasMetric() bool {
+	if t != nil && t.Metric != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetMetric allocates a new t.Metric and returns the pointer to it.
+func (t *TileDefProcessQuery) SetMetric(v string) {
+	t.Metric = &v
+}
+
+// GetSearchBy returns the SearchBy field if non-nil, zero value otherwise.
+func (t *TileDefProcessQuery) GetSearchBy() string {
+	if t == nil || t.SearchBy == nil {
+		return ""
+	}
+	return *t.SearchBy
+}
+
+// GetSearchByOk returns a tuple with the SearchBy field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefProcessQuery) GetSearchByOk() (string, bool) {
+	if t == nil || t.SearchBy == nil {
+		return "", false
+	}
+	return *t.SearchBy, true
+}
+
+// HasSearchBy returns a boolean if a field has been set.
+func (t *TileDefProcessQuery) HasSearchBy() bool {
+	if t != nil && t.SearchBy != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSearchBy allocates a new t.SearchBy and returns the pointer to it.
+func (t *TileDefProcessQuery) SetSearchBy(v string) {
+	t.SearchBy = &v
+}
+
 // GetAggregator returns the Aggregator field if non-nil, zero value otherwise.
 func (t *TileDefRequest) GetAggregator() string {
 	if t == nil || t.Aggregator == nil {
@@ -17775,6 +18023,37 @@ func (t *TileDefRequest) HasAggregator() bool {
 // SetAggregator allocates a new t.Aggregator and returns the pointer to it.
 func (t *TileDefRequest) SetAggregator(v string) {
 	t.Aggregator = &v
+}
+
+// GetAPMQuery returns the APMQuery field if non-nil, zero value otherwise.
+func (t *TileDefRequest) GetAPMQuery() TileDefApmOrLogQuery {
+	if t == nil || t.APMQuery == nil {
+		return TileDefApmOrLogQuery{}
+	}
+	return *t.APMQuery
+}
+
+// GetAPMQueryOk returns a tuple with the APMQuery field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefRequest) GetAPMQueryOk() (TileDefApmOrLogQuery, bool) {
+	if t == nil || t.APMQuery == nil {
+		return TileDefApmOrLogQuery{}, false
+	}
+	return *t.APMQuery, true
+}
+
+// HasAPMQuery returns a boolean if a field has been set.
+func (t *TileDefRequest) HasAPMQuery() bool {
+	if t != nil && t.APMQuery != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAPMQuery allocates a new t.APMQuery and returns the pointer to it.
+func (t *TileDefRequest) SetAPMQuery(v TileDefApmOrLogQuery) {
+	t.APMQuery = &v
 }
 
 // GetChangeType returns the ChangeType field if non-nil, zero value otherwise.
@@ -18054,6 +18333,37 @@ func (t *TileDefRequest) HasOrderDir() bool {
 // SetOrderDir allocates a new t.OrderDir and returns the pointer to it.
 func (t *TileDefRequest) SetOrderDir(v string) {
 	t.OrderDir = &v
+}
+
+// GetProcessQuery returns the ProcessQuery field if non-nil, zero value otherwise.
+func (t *TileDefRequest) GetProcessQuery() TileDefProcessQuery {
+	if t == nil || t.ProcessQuery == nil {
+		return TileDefProcessQuery{}
+	}
+	return *t.ProcessQuery
+}
+
+// GetProcessQueryOk returns a tuple with the ProcessQuery field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefRequest) GetProcessQueryOk() (TileDefProcessQuery, bool) {
+	if t == nil || t.ProcessQuery == nil {
+		return TileDefProcessQuery{}, false
+	}
+	return *t.ProcessQuery, true
+}
+
+// HasProcessQuery returns a boolean if a field has been set.
+func (t *TileDefRequest) HasProcessQuery() bool {
+	if t != nil && t.ProcessQuery != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetProcessQuery allocates a new t.ProcessQuery and returns the pointer to it.
+func (t *TileDefRequest) SetProcessQuery(v TileDefProcessQuery) {
+	t.ProcessQuery = &v
 }
 
 // GetQuery returns the Query field if non-nil, zero value otherwise.

--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -6090,6 +6090,409 @@ func (g *Graph) SetTitle(v string) {
 	g.Title = &v
 }
 
+// GetCompute returns the Compute field if non-nil, zero value otherwise.
+func (g *GraphApmOrLogQuery) GetCompute() GraphApmOrLogQueryCompute {
+	if g == nil || g.Compute == nil {
+		return GraphApmOrLogQueryCompute{}
+	}
+	return *g.Compute
+}
+
+// GetComputeOk returns a tuple with the Compute field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (g *GraphApmOrLogQuery) GetComputeOk() (GraphApmOrLogQueryCompute, bool) {
+	if g == nil || g.Compute == nil {
+		return GraphApmOrLogQueryCompute{}, false
+	}
+	return *g.Compute, true
+}
+
+// HasCompute returns a boolean if a field has been set.
+func (g *GraphApmOrLogQuery) HasCompute() bool {
+	if g != nil && g.Compute != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCompute allocates a new g.Compute and returns the pointer to it.
+func (g *GraphApmOrLogQuery) SetCompute(v GraphApmOrLogQueryCompute) {
+	g.Compute = &v
+}
+
+// GetIndex returns the Index field if non-nil, zero value otherwise.
+func (g *GraphApmOrLogQuery) GetIndex() string {
+	if g == nil || g.Index == nil {
+		return ""
+	}
+	return *g.Index
+}
+
+// GetIndexOk returns a tuple with the Index field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (g *GraphApmOrLogQuery) GetIndexOk() (string, bool) {
+	if g == nil || g.Index == nil {
+		return "", false
+	}
+	return *g.Index, true
+}
+
+// HasIndex returns a boolean if a field has been set.
+func (g *GraphApmOrLogQuery) HasIndex() bool {
+	if g != nil && g.Index != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetIndex allocates a new g.Index and returns the pointer to it.
+func (g *GraphApmOrLogQuery) SetIndex(v string) {
+	g.Index = &v
+}
+
+// GetSearch returns the Search field if non-nil, zero value otherwise.
+func (g *GraphApmOrLogQuery) GetSearch() GraphApmOrLogQuerySearch {
+	if g == nil || g.Search == nil {
+		return GraphApmOrLogQuerySearch{}
+	}
+	return *g.Search
+}
+
+// GetSearchOk returns a tuple with the Search field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (g *GraphApmOrLogQuery) GetSearchOk() (GraphApmOrLogQuerySearch, bool) {
+	if g == nil || g.Search == nil {
+		return GraphApmOrLogQuerySearch{}, false
+	}
+	return *g.Search, true
+}
+
+// HasSearch returns a boolean if a field has been set.
+func (g *GraphApmOrLogQuery) HasSearch() bool {
+	if g != nil && g.Search != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSearch allocates a new g.Search and returns the pointer to it.
+func (g *GraphApmOrLogQuery) SetSearch(v GraphApmOrLogQuerySearch) {
+	g.Search = &v
+}
+
+// GetAggregation returns the Aggregation field if non-nil, zero value otherwise.
+func (g *GraphApmOrLogQueryCompute) GetAggregation() string {
+	if g == nil || g.Aggregation == nil {
+		return ""
+	}
+	return *g.Aggregation
+}
+
+// GetAggregationOk returns a tuple with the Aggregation field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (g *GraphApmOrLogQueryCompute) GetAggregationOk() (string, bool) {
+	if g == nil || g.Aggregation == nil {
+		return "", false
+	}
+	return *g.Aggregation, true
+}
+
+// HasAggregation returns a boolean if a field has been set.
+func (g *GraphApmOrLogQueryCompute) HasAggregation() bool {
+	if g != nil && g.Aggregation != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAggregation allocates a new g.Aggregation and returns the pointer to it.
+func (g *GraphApmOrLogQueryCompute) SetAggregation(v string) {
+	g.Aggregation = &v
+}
+
+// GetFacet returns the Facet field if non-nil, zero value otherwise.
+func (g *GraphApmOrLogQueryCompute) GetFacet() string {
+	if g == nil || g.Facet == nil {
+		return ""
+	}
+	return *g.Facet
+}
+
+// GetFacetOk returns a tuple with the Facet field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (g *GraphApmOrLogQueryCompute) GetFacetOk() (string, bool) {
+	if g == nil || g.Facet == nil {
+		return "", false
+	}
+	return *g.Facet, true
+}
+
+// HasFacet returns a boolean if a field has been set.
+func (g *GraphApmOrLogQueryCompute) HasFacet() bool {
+	if g != nil && g.Facet != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetFacet allocates a new g.Facet and returns the pointer to it.
+func (g *GraphApmOrLogQueryCompute) SetFacet(v string) {
+	g.Facet = &v
+}
+
+// GetInterval returns the Interval field if non-nil, zero value otherwise.
+func (g *GraphApmOrLogQueryCompute) GetInterval() int {
+	if g == nil || g.Interval == nil {
+		return 0
+	}
+	return *g.Interval
+}
+
+// GetIntervalOk returns a tuple with the Interval field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (g *GraphApmOrLogQueryCompute) GetIntervalOk() (int, bool) {
+	if g == nil || g.Interval == nil {
+		return 0, false
+	}
+	return *g.Interval, true
+}
+
+// HasInterval returns a boolean if a field has been set.
+func (g *GraphApmOrLogQueryCompute) HasInterval() bool {
+	if g != nil && g.Interval != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetInterval allocates a new g.Interval and returns the pointer to it.
+func (g *GraphApmOrLogQueryCompute) SetInterval(v int) {
+	g.Interval = &v
+}
+
+// GetFacet returns the Facet field if non-nil, zero value otherwise.
+func (g *GraphApmOrLogQueryGroupBy) GetFacet() string {
+	if g == nil || g.Facet == nil {
+		return ""
+	}
+	return *g.Facet
+}
+
+// GetFacetOk returns a tuple with the Facet field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (g *GraphApmOrLogQueryGroupBy) GetFacetOk() (string, bool) {
+	if g == nil || g.Facet == nil {
+		return "", false
+	}
+	return *g.Facet, true
+}
+
+// HasFacet returns a boolean if a field has been set.
+func (g *GraphApmOrLogQueryGroupBy) HasFacet() bool {
+	if g != nil && g.Facet != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetFacet allocates a new g.Facet and returns the pointer to it.
+func (g *GraphApmOrLogQueryGroupBy) SetFacet(v string) {
+	g.Facet = &v
+}
+
+// GetLimit returns the Limit field if non-nil, zero value otherwise.
+func (g *GraphApmOrLogQueryGroupBy) GetLimit() int {
+	if g == nil || g.Limit == nil {
+		return 0
+	}
+	return *g.Limit
+}
+
+// GetLimitOk returns a tuple with the Limit field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (g *GraphApmOrLogQueryGroupBy) GetLimitOk() (int, bool) {
+	if g == nil || g.Limit == nil {
+		return 0, false
+	}
+	return *g.Limit, true
+}
+
+// HasLimit returns a boolean if a field has been set.
+func (g *GraphApmOrLogQueryGroupBy) HasLimit() bool {
+	if g != nil && g.Limit != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetLimit allocates a new g.Limit and returns the pointer to it.
+func (g *GraphApmOrLogQueryGroupBy) SetLimit(v int) {
+	g.Limit = &v
+}
+
+// GetSort returns the Sort field if non-nil, zero value otherwise.
+func (g *GraphApmOrLogQueryGroupBy) GetSort() GraphApmOrLogQueryGroupBySort {
+	if g == nil || g.Sort == nil {
+		return GraphApmOrLogQueryGroupBySort{}
+	}
+	return *g.Sort
+}
+
+// GetSortOk returns a tuple with the Sort field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (g *GraphApmOrLogQueryGroupBy) GetSortOk() (GraphApmOrLogQueryGroupBySort, bool) {
+	if g == nil || g.Sort == nil {
+		return GraphApmOrLogQueryGroupBySort{}, false
+	}
+	return *g.Sort, true
+}
+
+// HasSort returns a boolean if a field has been set.
+func (g *GraphApmOrLogQueryGroupBy) HasSort() bool {
+	if g != nil && g.Sort != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSort allocates a new g.Sort and returns the pointer to it.
+func (g *GraphApmOrLogQueryGroupBy) SetSort(v GraphApmOrLogQueryGroupBySort) {
+	g.Sort = &v
+}
+
+// GetAggregation returns the Aggregation field if non-nil, zero value otherwise.
+func (g *GraphApmOrLogQueryGroupBySort) GetAggregation() string {
+	if g == nil || g.Aggregation == nil {
+		return ""
+	}
+	return *g.Aggregation
+}
+
+// GetAggregationOk returns a tuple with the Aggregation field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (g *GraphApmOrLogQueryGroupBySort) GetAggregationOk() (string, bool) {
+	if g == nil || g.Aggregation == nil {
+		return "", false
+	}
+	return *g.Aggregation, true
+}
+
+// HasAggregation returns a boolean if a field has been set.
+func (g *GraphApmOrLogQueryGroupBySort) HasAggregation() bool {
+	if g != nil && g.Aggregation != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAggregation allocates a new g.Aggregation and returns the pointer to it.
+func (g *GraphApmOrLogQueryGroupBySort) SetAggregation(v string) {
+	g.Aggregation = &v
+}
+
+// GetFacet returns the Facet field if non-nil, zero value otherwise.
+func (g *GraphApmOrLogQueryGroupBySort) GetFacet() string {
+	if g == nil || g.Facet == nil {
+		return ""
+	}
+	return *g.Facet
+}
+
+// GetFacetOk returns a tuple with the Facet field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (g *GraphApmOrLogQueryGroupBySort) GetFacetOk() (string, bool) {
+	if g == nil || g.Facet == nil {
+		return "", false
+	}
+	return *g.Facet, true
+}
+
+// HasFacet returns a boolean if a field has been set.
+func (g *GraphApmOrLogQueryGroupBySort) HasFacet() bool {
+	if g != nil && g.Facet != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetFacet allocates a new g.Facet and returns the pointer to it.
+func (g *GraphApmOrLogQueryGroupBySort) SetFacet(v string) {
+	g.Facet = &v
+}
+
+// GetOrder returns the Order field if non-nil, zero value otherwise.
+func (g *GraphApmOrLogQueryGroupBySort) GetOrder() string {
+	if g == nil || g.Order == nil {
+		return ""
+	}
+	return *g.Order
+}
+
+// GetOrderOk returns a tuple with the Order field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (g *GraphApmOrLogQueryGroupBySort) GetOrderOk() (string, bool) {
+	if g == nil || g.Order == nil {
+		return "", false
+	}
+	return *g.Order, true
+}
+
+// HasOrder returns a boolean if a field has been set.
+func (g *GraphApmOrLogQueryGroupBySort) HasOrder() bool {
+	if g != nil && g.Order != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetOrder allocates a new g.Order and returns the pointer to it.
+func (g *GraphApmOrLogQueryGroupBySort) SetOrder(v string) {
+	g.Order = &v
+}
+
+// GetQuery returns the Query field if non-nil, zero value otherwise.
+func (g *GraphApmOrLogQuerySearch) GetQuery() string {
+	if g == nil || g.Query == nil {
+		return ""
+	}
+	return *g.Query
+}
+
+// GetQueryOk returns a tuple with the Query field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (g *GraphApmOrLogQuerySearch) GetQueryOk() (string, bool) {
+	if g == nil || g.Query == nil {
+		return "", false
+	}
+	return *g.Query, true
+}
+
+// HasQuery returns a boolean if a field has been set.
+func (g *GraphApmOrLogQuerySearch) HasQuery() bool {
+	if g != nil && g.Query != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetQuery allocates a new g.Query and returns the pointer to it.
+func (g *GraphApmOrLogQuerySearch) SetQuery(v string) {
+	g.Query = &v
+}
+
 // GetAutoscale returns the Autoscale field if non-nil, zero value otherwise.
 func (g *GraphDefinition) GetAutoscale() bool {
 	if g == nil || g.Autoscale == nil {
@@ -6708,6 +7111,37 @@ func (g *GraphDefinitionRequest) HasIncreaseGood() bool {
 // SetIncreaseGood allocates a new g.IncreaseGood and returns the pointer to it.
 func (g *GraphDefinitionRequest) SetIncreaseGood(v bool) {
 	g.IncreaseGood = &v
+}
+
+// GetLogQuery returns the LogQuery field if non-nil, zero value otherwise.
+func (g *GraphDefinitionRequest) GetLogQuery() GraphApmOrLogQuery {
+	if g == nil || g.LogQuery == nil {
+		return GraphApmOrLogQuery{}
+	}
+	return *g.LogQuery
+}
+
+// GetLogQueryOk returns a tuple with the LogQuery field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (g *GraphDefinitionRequest) GetLogQueryOk() (GraphApmOrLogQuery, bool) {
+	if g == nil || g.LogQuery == nil {
+		return GraphApmOrLogQuery{}, false
+	}
+	return *g.LogQuery, true
+}
+
+// HasLogQuery returns a boolean if a field has been set.
+func (g *GraphDefinitionRequest) HasLogQuery() bool {
+	if g != nil && g.LogQuery != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetLogQuery allocates a new g.LogQuery and returns the pointer to it.
+func (g *GraphDefinitionRequest) SetLogQuery(v GraphApmOrLogQuery) {
+	g.LogQuery = &v
 }
 
 // GetOrderBy returns the OrderBy field if non-nil, zero value otherwise.
@@ -16754,6 +17188,409 @@ func (t *TileDef) SetViz(v string) {
 	t.Viz = &v
 }
 
+// GetCompute returns the Compute field if non-nil, zero value otherwise.
+func (t *TileDefApmOrLogQuery) GetCompute() TileDefApmOrLogQueryCompute {
+	if t == nil || t.Compute == nil {
+		return TileDefApmOrLogQueryCompute{}
+	}
+	return *t.Compute
+}
+
+// GetComputeOk returns a tuple with the Compute field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefApmOrLogQuery) GetComputeOk() (TileDefApmOrLogQueryCompute, bool) {
+	if t == nil || t.Compute == nil {
+		return TileDefApmOrLogQueryCompute{}, false
+	}
+	return *t.Compute, true
+}
+
+// HasCompute returns a boolean if a field has been set.
+func (t *TileDefApmOrLogQuery) HasCompute() bool {
+	if t != nil && t.Compute != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCompute allocates a new t.Compute and returns the pointer to it.
+func (t *TileDefApmOrLogQuery) SetCompute(v TileDefApmOrLogQueryCompute) {
+	t.Compute = &v
+}
+
+// GetIndex returns the Index field if non-nil, zero value otherwise.
+func (t *TileDefApmOrLogQuery) GetIndex() string {
+	if t == nil || t.Index == nil {
+		return ""
+	}
+	return *t.Index
+}
+
+// GetIndexOk returns a tuple with the Index field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefApmOrLogQuery) GetIndexOk() (string, bool) {
+	if t == nil || t.Index == nil {
+		return "", false
+	}
+	return *t.Index, true
+}
+
+// HasIndex returns a boolean if a field has been set.
+func (t *TileDefApmOrLogQuery) HasIndex() bool {
+	if t != nil && t.Index != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetIndex allocates a new t.Index and returns the pointer to it.
+func (t *TileDefApmOrLogQuery) SetIndex(v string) {
+	t.Index = &v
+}
+
+// GetSearch returns the Search field if non-nil, zero value otherwise.
+func (t *TileDefApmOrLogQuery) GetSearch() TileDefApmOrLogQuerySearch {
+	if t == nil || t.Search == nil {
+		return TileDefApmOrLogQuerySearch{}
+	}
+	return *t.Search
+}
+
+// GetSearchOk returns a tuple with the Search field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefApmOrLogQuery) GetSearchOk() (TileDefApmOrLogQuerySearch, bool) {
+	if t == nil || t.Search == nil {
+		return TileDefApmOrLogQuerySearch{}, false
+	}
+	return *t.Search, true
+}
+
+// HasSearch returns a boolean if a field has been set.
+func (t *TileDefApmOrLogQuery) HasSearch() bool {
+	if t != nil && t.Search != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSearch allocates a new t.Search and returns the pointer to it.
+func (t *TileDefApmOrLogQuery) SetSearch(v TileDefApmOrLogQuerySearch) {
+	t.Search = &v
+}
+
+// GetAggregation returns the Aggregation field if non-nil, zero value otherwise.
+func (t *TileDefApmOrLogQueryCompute) GetAggregation() string {
+	if t == nil || t.Aggregation == nil {
+		return ""
+	}
+	return *t.Aggregation
+}
+
+// GetAggregationOk returns a tuple with the Aggregation field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefApmOrLogQueryCompute) GetAggregationOk() (string, bool) {
+	if t == nil || t.Aggregation == nil {
+		return "", false
+	}
+	return *t.Aggregation, true
+}
+
+// HasAggregation returns a boolean if a field has been set.
+func (t *TileDefApmOrLogQueryCompute) HasAggregation() bool {
+	if t != nil && t.Aggregation != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAggregation allocates a new t.Aggregation and returns the pointer to it.
+func (t *TileDefApmOrLogQueryCompute) SetAggregation(v string) {
+	t.Aggregation = &v
+}
+
+// GetFacet returns the Facet field if non-nil, zero value otherwise.
+func (t *TileDefApmOrLogQueryCompute) GetFacet() string {
+	if t == nil || t.Facet == nil {
+		return ""
+	}
+	return *t.Facet
+}
+
+// GetFacetOk returns a tuple with the Facet field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefApmOrLogQueryCompute) GetFacetOk() (string, bool) {
+	if t == nil || t.Facet == nil {
+		return "", false
+	}
+	return *t.Facet, true
+}
+
+// HasFacet returns a boolean if a field has been set.
+func (t *TileDefApmOrLogQueryCompute) HasFacet() bool {
+	if t != nil && t.Facet != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetFacet allocates a new t.Facet and returns the pointer to it.
+func (t *TileDefApmOrLogQueryCompute) SetFacet(v string) {
+	t.Facet = &v
+}
+
+// GetInterval returns the Interval field if non-nil, zero value otherwise.
+func (t *TileDefApmOrLogQueryCompute) GetInterval() int {
+	if t == nil || t.Interval == nil {
+		return 0
+	}
+	return *t.Interval
+}
+
+// GetIntervalOk returns a tuple with the Interval field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefApmOrLogQueryCompute) GetIntervalOk() (int, bool) {
+	if t == nil || t.Interval == nil {
+		return 0, false
+	}
+	return *t.Interval, true
+}
+
+// HasInterval returns a boolean if a field has been set.
+func (t *TileDefApmOrLogQueryCompute) HasInterval() bool {
+	if t != nil && t.Interval != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetInterval allocates a new t.Interval and returns the pointer to it.
+func (t *TileDefApmOrLogQueryCompute) SetInterval(v int) {
+	t.Interval = &v
+}
+
+// GetFacet returns the Facet field if non-nil, zero value otherwise.
+func (t *TileDefApmOrLogQueryGroupBy) GetFacet() string {
+	if t == nil || t.Facet == nil {
+		return ""
+	}
+	return *t.Facet
+}
+
+// GetFacetOk returns a tuple with the Facet field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefApmOrLogQueryGroupBy) GetFacetOk() (string, bool) {
+	if t == nil || t.Facet == nil {
+		return "", false
+	}
+	return *t.Facet, true
+}
+
+// HasFacet returns a boolean if a field has been set.
+func (t *TileDefApmOrLogQueryGroupBy) HasFacet() bool {
+	if t != nil && t.Facet != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetFacet allocates a new t.Facet and returns the pointer to it.
+func (t *TileDefApmOrLogQueryGroupBy) SetFacet(v string) {
+	t.Facet = &v
+}
+
+// GetLimit returns the Limit field if non-nil, zero value otherwise.
+func (t *TileDefApmOrLogQueryGroupBy) GetLimit() int {
+	if t == nil || t.Limit == nil {
+		return 0
+	}
+	return *t.Limit
+}
+
+// GetLimitOk returns a tuple with the Limit field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefApmOrLogQueryGroupBy) GetLimitOk() (int, bool) {
+	if t == nil || t.Limit == nil {
+		return 0, false
+	}
+	return *t.Limit, true
+}
+
+// HasLimit returns a boolean if a field has been set.
+func (t *TileDefApmOrLogQueryGroupBy) HasLimit() bool {
+	if t != nil && t.Limit != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetLimit allocates a new t.Limit and returns the pointer to it.
+func (t *TileDefApmOrLogQueryGroupBy) SetLimit(v int) {
+	t.Limit = &v
+}
+
+// GetSort returns the Sort field if non-nil, zero value otherwise.
+func (t *TileDefApmOrLogQueryGroupBy) GetSort() TileDefApmOrLogQueryGroupBySort {
+	if t == nil || t.Sort == nil {
+		return TileDefApmOrLogQueryGroupBySort{}
+	}
+	return *t.Sort
+}
+
+// GetSortOk returns a tuple with the Sort field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefApmOrLogQueryGroupBy) GetSortOk() (TileDefApmOrLogQueryGroupBySort, bool) {
+	if t == nil || t.Sort == nil {
+		return TileDefApmOrLogQueryGroupBySort{}, false
+	}
+	return *t.Sort, true
+}
+
+// HasSort returns a boolean if a field has been set.
+func (t *TileDefApmOrLogQueryGroupBy) HasSort() bool {
+	if t != nil && t.Sort != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSort allocates a new t.Sort and returns the pointer to it.
+func (t *TileDefApmOrLogQueryGroupBy) SetSort(v TileDefApmOrLogQueryGroupBySort) {
+	t.Sort = &v
+}
+
+// GetAggregation returns the Aggregation field if non-nil, zero value otherwise.
+func (t *TileDefApmOrLogQueryGroupBySort) GetAggregation() string {
+	if t == nil || t.Aggregation == nil {
+		return ""
+	}
+	return *t.Aggregation
+}
+
+// GetAggregationOk returns a tuple with the Aggregation field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefApmOrLogQueryGroupBySort) GetAggregationOk() (string, bool) {
+	if t == nil || t.Aggregation == nil {
+		return "", false
+	}
+	return *t.Aggregation, true
+}
+
+// HasAggregation returns a boolean if a field has been set.
+func (t *TileDefApmOrLogQueryGroupBySort) HasAggregation() bool {
+	if t != nil && t.Aggregation != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAggregation allocates a new t.Aggregation and returns the pointer to it.
+func (t *TileDefApmOrLogQueryGroupBySort) SetAggregation(v string) {
+	t.Aggregation = &v
+}
+
+// GetFacet returns the Facet field if non-nil, zero value otherwise.
+func (t *TileDefApmOrLogQueryGroupBySort) GetFacet() string {
+	if t == nil || t.Facet == nil {
+		return ""
+	}
+	return *t.Facet
+}
+
+// GetFacetOk returns a tuple with the Facet field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefApmOrLogQueryGroupBySort) GetFacetOk() (string, bool) {
+	if t == nil || t.Facet == nil {
+		return "", false
+	}
+	return *t.Facet, true
+}
+
+// HasFacet returns a boolean if a field has been set.
+func (t *TileDefApmOrLogQueryGroupBySort) HasFacet() bool {
+	if t != nil && t.Facet != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetFacet allocates a new t.Facet and returns the pointer to it.
+func (t *TileDefApmOrLogQueryGroupBySort) SetFacet(v string) {
+	t.Facet = &v
+}
+
+// GetOrder returns the Order field if non-nil, zero value otherwise.
+func (t *TileDefApmOrLogQueryGroupBySort) GetOrder() string {
+	if t == nil || t.Order == nil {
+		return ""
+	}
+	return *t.Order
+}
+
+// GetOrderOk returns a tuple with the Order field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefApmOrLogQueryGroupBySort) GetOrderOk() (string, bool) {
+	if t == nil || t.Order == nil {
+		return "", false
+	}
+	return *t.Order, true
+}
+
+// HasOrder returns a boolean if a field has been set.
+func (t *TileDefApmOrLogQueryGroupBySort) HasOrder() bool {
+	if t != nil && t.Order != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetOrder allocates a new t.Order and returns the pointer to it.
+func (t *TileDefApmOrLogQueryGroupBySort) SetOrder(v string) {
+	t.Order = &v
+}
+
+// GetQuery returns the Query field if non-nil, zero value otherwise.
+func (t *TileDefApmOrLogQuerySearch) GetQuery() string {
+	if t == nil || t.Query == nil {
+		return ""
+	}
+	return *t.Query
+}
+
+// GetQueryOk returns a tuple with the Query field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefApmOrLogQuerySearch) GetQueryOk() (string, bool) {
+	if t == nil || t.Query == nil {
+		return "", false
+	}
+	return *t.Query, true
+}
+
+// HasQuery returns a boolean if a field has been set.
+func (t *TileDefApmOrLogQuerySearch) HasQuery() bool {
+	if t != nil && t.Query != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetQuery allocates a new t.Query and returns the pointer to it.
+func (t *TileDefApmOrLogQuerySearch) SetQuery(v string) {
+	t.Query = &v
+}
+
 // GetQuery returns the Query field if non-nil, zero value otherwise.
 func (t *TileDefEvent) GetQuery() string {
 	if t == nil || t.Query == nil {
@@ -17093,6 +17930,37 @@ func (t *TileDefRequest) HasLimit() bool {
 // SetLimit allocates a new t.Limit and returns the pointer to it.
 func (t *TileDefRequest) SetLimit(v int) {
 	t.Limit = &v
+}
+
+// GetLogQuery returns the LogQuery field if non-nil, zero value otherwise.
+func (t *TileDefRequest) GetLogQuery() TileDefApmOrLogQuery {
+	if t == nil || t.LogQuery == nil {
+		return TileDefApmOrLogQuery{}
+	}
+	return *t.LogQuery
+}
+
+// GetLogQueryOk returns a tuple with the LogQuery field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TileDefRequest) GetLogQueryOk() (TileDefApmOrLogQuery, bool) {
+	if t == nil || t.LogQuery == nil {
+		return TileDefApmOrLogQuery{}, false
+	}
+	return *t.LogQuery, true
+}
+
+// HasLogQuery returns a boolean if a field has been set.
+func (t *TileDefRequest) HasLogQuery() bool {
+	if t != nil && t.LogQuery != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetLogQuery allocates a new t.LogQuery and returns the pointer to it.
+func (t *TileDefRequest) SetLogQuery(v TileDefApmOrLogQuery) {
+	t.LogQuery = &v
 }
 
 // GetMetric returns the Metric field if non-nil, zero value otherwise.

--- a/integration/screen_widgets_test.go
+++ b/integration/screen_widgets_test.go
@@ -20,6 +20,7 @@ func TestWidgets(t *testing.T) {
 			FontSize:  datadog.String("36"),
 			Color:     datadog.String("#ffc0cb"),
 		},
+		// Timeseries widget with metrics query.
 		{
 			Type:       datadog.String("timeseries"),
 			X:          datadog.Int(1),
@@ -61,6 +62,146 @@ func TestWidgets(t *testing.T) {
 				}},
 			},
 		},
+		// Timeseries widget with log query.
+		{
+			Type:       datadog.String("timeseries"),
+			X:          datadog.Int(20),
+			Y:          datadog.Int(10),
+			Width:      datadog.Int(40),
+			Height:     datadog.Int(20),
+			Title:      datadog.Bool(true),
+			TitleText:  datadog.String("Test title 2"),
+			TitleSize:  datadog.Int(16),
+			TitleAlign: datadog.String("right"),
+			Legend:     datadog.Bool(true),
+			LegendSize: datadog.String("16"),
+			Time: &datadog.Time{
+				LiveSpan: datadog.String("1d"),
+			},
+			TileDef: &datadog.TileDef{
+				Viz: datadog.String("timeseries"),
+				Requests: []datadog.TileDefRequest{{
+					LogQuery: &datadog.TileDefApmOrLogQuery{
+						Index: datadog.String("avg"),
+						Compute: &datadog.TileDefApmOrLogQueryCompute{
+							Aggregation: datadog.String("count"),
+							Facet:       datadog.String("host"),
+							Interval:    datadog.Int(300000),
+						},
+						Search: &datadog.TileDefApmOrLogQuerySearch{},
+						GroupBy: []datadog.TileDefApmOrLogQueryGroupBy{{
+							Facet: datadog.String("host"),
+							Limit: datadog.Int(10),
+							Sort: &datadog.TileDefApmOrLogQueryGroupBySort{
+								Aggregation: datadog.String("count"),
+								Order:       datadog.String("desc"),
+							},
+						}},
+					},
+					Type: datadog.String("line"),
+					Style: &datadog.TileDefRequestStyle{
+						Palette: datadog.String("purple"),
+						Type:    datadog.String("dashed"),
+						Width:   datadog.String("thin"),
+					},
+				}},
+				Markers: []datadog.TileDefMarker{{
+					Label: datadog.String("test marker"),
+					Type:  datadog.String("error dashed"),
+					Value: datadog.String("y < 5"),
+				}},
+				Events: []datadog.TileDefEvent{{
+					Query: datadog.String("test event"),
+				}},
+			},
+		},
+		// Timeseries widget with Apm query.
+		{
+			Type:       datadog.String("timeseries"),
+			X:          datadog.Int(20),
+			Y:          datadog.Int(10),
+			Width:      datadog.Int(40),
+			Height:     datadog.Int(20),
+			Title:      datadog.Bool(true),
+			TitleText:  datadog.String("Test title 2"),
+			TitleSize:  datadog.Int(16),
+			TitleAlign: datadog.String("right"),
+			Legend:     datadog.Bool(true),
+			LegendSize: datadog.String("16"),
+			Time: &datadog.Time{
+				LiveSpan: datadog.String("1d"),
+			},
+			TileDef: &datadog.TileDef{
+				Viz: datadog.String("timeseries"),
+				Requests: []datadog.TileDefRequest{{
+					ApmQuery: &datadog.TileDefApmOrLogQuery{
+						Index: datadog.String("avg"),
+						Compute: &datadog.TileDefApmOrLogQueryCompute{
+							Aggregation: datadog.String("count"),
+							Facet:       datadog.String("host"),
+							Interval:    datadog.Int(300000),
+						},
+						Search:  &datadog.TileDefApmOrLogQuerySearch{},
+						GroupBy: []datadog.TileDefApmOrLogQueryGroupBy{{}},
+					},
+					Type: datadog.String("line"),
+					Style: &datadog.TileDefRequestStyle{
+						Palette: datadog.String("purple"),
+						Type:    datadog.String("dashed"),
+						Width:   datadog.String("thin"),
+					},
+				}},
+				Markers: []datadog.TileDefMarker{{
+					Label: datadog.String("test marker"),
+					Type:  datadog.String("error dashed"),
+					Value: datadog.String("y < 5"),
+				}},
+				Events: []datadog.TileDefEvent{{
+					Query: datadog.String("test event"),
+				}},
+			},
+		},
+		// Timeseries widget with process query.
+		{
+			Type:       datadog.String("timeseries"),
+			X:          datadog.Int(20),
+			Y:          datadog.Int(10),
+			Width:      datadog.Int(40),
+			Height:     datadog.Int(20),
+			Title:      datadog.Bool(true),
+			TitleText:  datadog.String("Test title 3"),
+			TitleSize:  datadog.Int(16),
+			TitleAlign: datadog.String("right"),
+			Legend:     datadog.Bool(true),
+			LegendSize: datadog.String("16"),
+			Time: &datadog.Time{
+				LiveSpan: datadog.String("1d"),
+			},
+			TileDef: &datadog.TileDef{
+				Viz: datadog.String("timeseries"),
+				Requests: []datadog.TileDefRequest{{
+					ProcessQuery: &datadog.TileDefProcessQuery{
+						Metric: datadog.String("process.stat.cpu.total_pct"),
+						Limit:  datadog.Int(10),
+					},
+					Type: datadog.String("line"),
+					Style: &datadog.TileDefRequestStyle{
+						Palette: datadog.String("purple"),
+						Type:    datadog.String("dashed"),
+						Width:   datadog.String("thin"),
+					},
+				}},
+				Markers: []datadog.TileDefMarker{{
+					Label: datadog.String("test marker"),
+					Type:  datadog.String("error dashed"),
+					Value: datadog.String("y < 5"),
+				}},
+				Events: []datadog.TileDefEvent{{
+					Query: datadog.String("test event"),
+				}},
+			},
+		},
+
 		{
 			Type:       datadog.String("query_value"),
 			X:          datadog.Int(1),

--- a/screen_widgets.go
+++ b/screen_widgets.go
@@ -68,9 +68,10 @@ type TileDefRequest struct {
 	TagFilters []*string `json:"tag_filters"`
 	Limit      *int      `json:"limit,omitempty"`
 
+	// A Widget can only have one of these types of query.
 	Query        *string               `json:"q,omitempty"`
 	LogQuery     *TileDefApmOrLogQuery `json:"log_query,omitempty"`
-	APMQuery     *TileDefApmOrLogQuery `json:"apm_query,omitempty"`
+	ApmQuery     *TileDefApmOrLogQuery `json:"apm_query,omitempty"`
 	ProcessQuery *TileDefProcessQuery  `json:"process_query,omitempty"`
 
 	ConditionalFormats []ConditionalFormat        `json:"conditional_formats,omitempty"`

--- a/screen_widgets.go
+++ b/screen_widgets.go
@@ -69,6 +69,9 @@ type TileDefRequest struct {
 	TagFilters []*string `json:"tag_filters"`
 	Limit      *int      `json:"limit,omitempty"`
 
+	// For APM or log query
+	LogQuery *TileDefApmOrLogQuery `json:"log_query,omitempty"`
+
 	ConditionalFormats []ConditionalFormat        `json:"conditional_formats,omitempty"`
 	Style              *TileDefRequestStyle       `json:"style,omitempty"`
 	Aggregator         *string                    `json:"aggregator,omitempty"`
@@ -79,6 +82,32 @@ type TileDefRequest struct {
 	ExtraCol           *string                    `json:"extra_col,omitempty"`
 	IncreaseGood       *bool                      `json:"increase_good,omitempty"`
 	Metadata           map[string]TileDefMetadata `json:"metadata,omitempty"`
+}
+
+// TileDefApmOrLogQuery represents an APM or a Log query
+type TileDefApmOrLogQuery struct {
+	Index   *string                       `json:"index"`
+	Compute *TileDefApmOrLogQueryCompute  `json:"compute"`
+	Search  *TileDefApmOrLogQuerySearch   `json:"search,omitempty"`
+	GroupBy []TileDefApmOrLogQueryGroupBy `json:"groupBy,omitempty"`
+}
+type TileDefApmOrLogQueryCompute struct {
+	Aggregation *string `json:"aggregation"`
+	Facet       *string `json:"facet,omitempty"`
+	Interval    *int    `json:"interval,omitempty"`
+}
+type TileDefApmOrLogQuerySearch struct {
+	Query *string `json:"query"`
+}
+type TileDefApmOrLogQueryGroupBy struct {
+	Facet *string                          `json:"facet"`
+	Limit *int                             `json:"limit,omitempty"`
+	Sort  *TileDefApmOrLogQueryGroupBySort `json:"sort,omitempty"`
+}
+type TileDefApmOrLogQueryGroupBySort struct {
+	Aggregation *string `json:"aggregation"`
+	Order       *string `json:"order"`
+	Facet       *string `json:"facet,omitempty"`
 }
 
 type TileDefMetadata struct {

--- a/screen_widgets.go
+++ b/screen_widgets.go
@@ -57,7 +57,6 @@ type TileDefMarker struct {
 }
 
 type TileDefRequest struct {
-	Query *string `json:"q,omitempty"`
 
 	// For Hostmap
 	Type *string `json:"type,omitempty"`
@@ -69,8 +68,10 @@ type TileDefRequest struct {
 	TagFilters []*string `json:"tag_filters"`
 	Limit      *int      `json:"limit,omitempty"`
 
-	// For APM or log query
-	LogQuery *TileDefApmOrLogQuery `json:"log_query,omitempty"`
+	Query        *string               `json:"q,omitempty"`
+	LogQuery     *TileDefApmOrLogQuery `json:"log_query,omitempty"`
+	APMQuery     *TileDefApmOrLogQuery `json:"apm_query,omitempty"`
+	ProcessQuery *TileDefProcessQuery  `json:"process_query,omitempty"`
 
 	ConditionalFormats []ConditionalFormat        `json:"conditional_formats,omitempty"`
 	Style              *TileDefRequestStyle       `json:"style,omitempty"`
@@ -108,6 +109,13 @@ type TileDefApmOrLogQueryGroupBySort struct {
 	Aggregation *string `json:"aggregation"`
 	Order       *string `json:"order"`
 	Facet       *string `json:"facet,omitempty"`
+}
+
+type TileDefProcessQuery struct {
+	Metric   *string  `json:"metric"`
+	SearchBy *string  `json:"search_by,omitempty"`
+	FilterBy []string `json:"filter_by,omitempty"`
+	Limit    *int     `json:"limit,omitempty"`
 }
 
 type TileDefMetadata struct {


### PR DESCRIPTION
This PR adds support for `log_query`, `apm_query` and `process_query` in legacy screenboards and timeboards API.

### Datadog JSON sample

```
{
  "requests": [
    {
      "log_query": {
        "index": "main",
        "search": {
          "query": "service:my-app AND status:error"
        },
        "groupBy": [],
        "compute": {
          "aggregation": "count",
          "facet": null,
          "interval": "300000"
        }
      },
      "aggregator": "count",
      "style": {
        "palette": "warm",
        "type": "solid",
        "width": "thick"
      },
      "type": "line",
      "conditional_formats": []
    }
  ],
  "viz": "timeseries",
  "autoscale": true,
  "yaxis": {
    "scale": "log",
    "includeZero": false
  },
  "status": "done"
}
```