### PR TITLE
[dashboards] Update interval type from int to string in screenboards from legacy api

### DIFF
--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -17685,18 +17685,18 @@ func (t *TileDefApmOrLogQueryCompute) SetFacet(v string) {
 }
 
 // GetInterval returns the Interval field if non-nil, zero value otherwise.
-func (t *TileDefApmOrLogQueryCompute) GetInterval() int {
+func (t *TileDefApmOrLogQueryCompute) GetInterval() string {
 	if t == nil || t.Interval == nil {
-		return 0
+		return ""
 	}
 	return *t.Interval
 }
 
 // GetIntervalOk returns a tuple with the Interval field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (t *TileDefApmOrLogQueryCompute) GetIntervalOk() (int, bool) {
+func (t *TileDefApmOrLogQueryCompute) GetIntervalOk() (string, bool) {
 	if t == nil || t.Interval == nil {
-		return 0, false
+		return "", false
 	}
 	return *t.Interval, true
 }
@@ -17711,7 +17711,7 @@ func (t *TileDefApmOrLogQueryCompute) HasInterval() bool {
 }
 
 // SetInterval allocates a new t.Interval and returns the pointer to it.
-func (t *TileDefApmOrLogQueryCompute) SetInterval(v int) {
+func (t *TileDefApmOrLogQueryCompute) SetInterval(v string) {
 	t.Interval = &v
 }
 

--- a/integration/screen_widgets_test.go
+++ b/integration/screen_widgets_test.go
@@ -86,7 +86,7 @@ func TestWidgets(t *testing.T) {
 						Compute: &datadog.TileDefApmOrLogQueryCompute{
 							Aggregation: datadog.String("count"),
 							Facet:       datadog.String("host"),
-							Interval:    datadog.Int(300000),
+							Interval:    datadog.String("300000"),
 						},
 						Search: &datadog.TileDefApmOrLogQuerySearch{},
 						GroupBy: []datadog.TileDefApmOrLogQueryGroupBy{{
@@ -139,7 +139,7 @@ func TestWidgets(t *testing.T) {
 						Compute: &datadog.TileDefApmOrLogQueryCompute{
 							Aggregation: datadog.String("count"),
 							Facet:       datadog.String("host"),
-							Interval:    datadog.Int(300000),
+							Interval:    datadog.String("300000"),
 						},
 						Search:  &datadog.TileDefApmOrLogQuerySearch{},
 						GroupBy: []datadog.TileDefApmOrLogQueryGroupBy{{}},

--- a/screen_widgets.go
+++ b/screen_widgets.go
@@ -96,7 +96,7 @@ type TileDefApmOrLogQuery struct {
 type TileDefApmOrLogQueryCompute struct {
 	Aggregation *string `json:"aggregation"`
 	Facet       *string `json:"facet,omitempty"`
-	Interval    *int    `json:"interval,omitempty"`
+	Interval    *string `json:"interval,omitempty"`
 }
 type TileDefApmOrLogQuerySearch struct {
 	Query *string `json:"query"`


### PR DESCRIPTION
In the legacy api, the interval type in the compute field of the log query is a string, not an integer.