### PR TITLE
Submit custom_fg_color instead of color

### DIFF
--- a/screen_widgets.go
+++ b/screen_widgets.go
@@ -124,7 +124,7 @@ type TileDefMetadata struct {
 }
 
 type ConditionalFormat struct {
-	Color         *string `json:"color,omitempty"`
+	Color         *string `json:"custom_fg_color,omitempty"`
 	Palette       *string `json:"palette,omitempty"`
 	Comparator    *string `json:"comparator,omitempty"`
 	Invert        *bool   `json:"invert,omitempty"`


### PR DESCRIPTION
The conditional formats section of screenboards should submit a field called `custom_fg_color` instead of `color`. Docs - https://docs.datadoghq.com/graphing/graphing_json/widget_json/#conditional-format-schema

Should still be backwards compatible since I left the struct alone and only changed what its un-marshalled as. 