### PR TITLE
Use api instead of app

### DIFF
--- a/client.go
+++ b/client.go
@@ -37,7 +37,7 @@ type valid struct {
 func NewClient(apiKey, appKey string) *Client {
 	baseUrl := os.Getenv("DATADOG_HOST")
 	if baseUrl == "" {
-		baseUrl = "https://app.datadoghq.com"
+		baseUrl = "https://api.datadoghq.com"
 	}
 
 	return &Client{


### PR DESCRIPTION
The updated base URL is `api.datadoghq.com`. Note: it's still possible to use `app.datadoghq.com` but updating it to make it consistent with what's on https://docs.datadoghq.com/api/?lang=bash#overview.