### PR TITLE
Add v2 of the dashboard_list_item API

### DIFF
--- a/dashboard_list_items_v2.go
+++ b/dashboard_list_items_v2.go
@@ -12,63 +12,63 @@ import (
 	"fmt"
 )
 
-// DashboardListV2Item represents a single dashboard in a dashboard list.
-type DashboardListV2Item struct {
+// DashboardListItemV2 represents a single dashboard in a dashboard list.
+type DashboardListItemV2 struct {
 	ID   *string `json:"id,omitempty"`
 	Type *string `json:"type,omitempty"`
 }
 
-type reqDashboardListV2Items struct {
-	Dashboards []DashboardListV2Item `json:"dashboards,omitempty"`
+type reqDashboardListItemsV2 struct {
+	Dashboards []DashboardListItemV2 `json:"dashboards,omitempty"`
 }
 
-type reqAddedDashboardListV2Items struct {
-	Dashboards []DashboardListV2Item `json:"added_dashboards_to_list,omitempty"`
+type reqAddedDashboardListItemsV2 struct {
+	Dashboards []DashboardListItemV2 `json:"added_dashboards_to_list,omitempty"`
 }
 
-type reqDeletedDashboardListV2Items struct {
-	Dashboards []DashboardListV2Item `json:"deleted_dashboards_from_list,omitempty"`
+type reqDeletedDashboardListItemsV2 struct {
+	Dashboards []DashboardListItemV2 `json:"deleted_dashboards_from_list,omitempty"`
 }
 
-// GetDashboardListV2Items fetches the dashboard list's dashboard definitions.
-func (client *Client) GetDashboardListV2Items(id int) ([]DashboardListV2Item, error) {
-	var out reqDashboardListV2Items
+// GetDashboardListItemsV2 fetches the dashboard list's dashboard definitions.
+func (client *Client) GetDashboardListItemsV2(id int) ([]DashboardListItemV2, error) {
+	var out reqDashboardListItemsV2
 	if err := client.doJsonRequest("GET", fmt.Sprintf("/v2/dashboard/lists/manual/%d/dashboards", id), nil, &out); err != nil {
 		return nil, err
 	}
 	return out.Dashboards, nil
 }
 
-// AddDashboardListV2Items adds dashboards to an existing dashboard list.
+// AddDashboardListItemsV2 adds dashboards to an existing dashboard list.
 //
 // Any items already in the list are ignored (not added twice).
-func (client *Client) AddDashboardListV2Items(dashboardListID int, items []DashboardListV2Item) ([]DashboardListV2Item, error) {
-	req := reqDashboardListV2Items{items}
-	var out reqAddedDashboardListV2Items
+func (client *Client) AddDashboardListItemsV2(dashboardListID int, items []DashboardListItemV2) ([]DashboardListItemV2, error) {
+	req := reqDashboardListItemsV2{items}
+	var out reqAddedDashboardListItemsV2
 	if err := client.doJsonRequest("POST", fmt.Sprintf("/v2/dashboard/lists/manual/%d/dashboards", dashboardListID), req, &out); err != nil {
 		return nil, err
 	}
 	return out.Dashboards, nil
 }
 
-// UpdateDashboardListV2Items updates dashboards of an existing dashboard list.
+// UpdateDashboardListItemsV2 updates dashboards of an existing dashboard list.
 //
 // This will set the list of dashboards to contain only the items in items.
-func (client *Client) UpdateDashboardListV2Items(dashboardListID int, items []DashboardListV2Item) ([]DashboardListV2Item, error) {
-	req := reqDashboardListV2Items{items}
-	var out reqDashboardListV2Items
+func (client *Client) UpdateDashboardListItemsV2(dashboardListID int, items []DashboardListItemV2) ([]DashboardListItemV2, error) {
+	req := reqDashboardListItemsV2{items}
+	var out reqDashboardListItemsV2
 	if err := client.doJsonRequest("PUT", fmt.Sprintf("/v2/dashboard/lists/manual/%d/dashboards", dashboardListID), req, &out); err != nil {
 		return nil, err
 	}
 	return out.Dashboards, nil
 }
 
-// DeleteDashboardListV2Items deletes dashboards from an existing dashboard list.
+// DeleteDashboardListItemsV2 deletes dashboards from an existing dashboard list.
 //
 // Deletes any dashboards in the list of items from the dashboard list.
-func (client *Client) DeleteDashboardListV2Items(dashboardListID int, items []DashboardListV2Item) ([]DashboardListV2Item, error) {
-	req := reqDashboardListV2Items{items}
-	var out reqDeletedDashboardListV2Items
+func (client *Client) DeleteDashboardListItemsV2(dashboardListID int, items []DashboardListItemV2) ([]DashboardListItemV2, error) {
+	req := reqDashboardListItemsV2{items}
+	var out reqDeletedDashboardListItemsV2
 	if err := client.doJsonRequest("DELETE", fmt.Sprintf("/v2/dashboard/lists/manual/%d/dashboards", dashboardListID), req, &out); err != nil {
 		return nil, err
 	}

--- a/dashboard_list_items_v2.go
+++ b/dashboard_list_items_v2.go
@@ -1,0 +1,76 @@
+/*
+ * Datadog API for Go
+ *
+ * Please see the included LICENSE file for licensing information.
+ *
+ * Copyright 2019 by authors and contributors.
+ */
+
+package datadog
+
+import (
+	"fmt"
+)
+
+// DashboardListV2Item represents a single dashboard in a dashboard list.
+type DashboardListV2Item struct {
+	ID   *string `json:"id,omitempty"`
+	Type *string `json:"type,omitempty"`
+}
+
+type reqDashboardListV2Items struct {
+	Dashboards []DashboardListV2Item `json:"dashboards,omitempty"`
+}
+
+type reqAddedDashboardListV2Items struct {
+	Dashboards []DashboardListV2Item `json:"added_dashboards_to_list,omitempty"`
+}
+
+type reqDeletedDashboardListV2Items struct {
+	Dashboards []DashboardListV2Item `json:"deleted_dashboards_from_list,omitempty"`
+}
+
+// GetDashboardListV2Items fetches the dashboard list's dashboard definitions.
+func (client *Client) GetDashboardListV2Items(id int) ([]DashboardListV2Item, error) {
+	var out reqDashboardListV2Items
+	if err := client.doJsonRequest("GET", fmt.Sprintf("/v2/dashboard/lists/manual/%d/dashboards", id), nil, &out); err != nil {
+		return nil, err
+	}
+	return out.Dashboards, nil
+}
+
+// AddDashboardListV2Items adds dashboards to an existing dashboard list.
+//
+// Any items already in the list are ignored (not added twice).
+func (client *Client) AddDashboardListV2Items(dashboardListID int, items []DashboardListV2Item) ([]DashboardListV2Item, error) {
+	req := reqDashboardListV2Items{items}
+	var out reqAddedDashboardListV2Items
+	if err := client.doJsonRequest("POST", fmt.Sprintf("/v2/dashboard/lists/manual/%d/dashboards", dashboardListID), req, &out); err != nil {
+		return nil, err
+	}
+	return out.Dashboards, nil
+}
+
+// UpdateDashboardListV2Items updates dashboards of an existing dashboard list.
+//
+// This will set the list of dashboards to contain only the items in items.
+func (client *Client) UpdateDashboardListV2Items(dashboardListID int, items []DashboardListV2Item) ([]DashboardListV2Item, error) {
+	req := reqDashboardListV2Items{items}
+	var out reqDashboardListV2Items
+	if err := client.doJsonRequest("PUT", fmt.Sprintf("/v2/dashboard/lists/manual/%d/dashboards", dashboardListID), req, &out); err != nil {
+		return nil, err
+	}
+	return out.Dashboards, nil
+}
+
+// DeleteDashboardListV2Items deletes dashboards from an existing dashboard list.
+//
+// Deletes any dashboards in the list of items from the dashboard list.
+func (client *Client) DeleteDashboardListV2Items(dashboardListID int, items []DashboardListV2Item) ([]DashboardListV2Item, error) {
+	req := reqDashboardListV2Items{items}
+	var out reqDeletedDashboardListV2Items
+	if err := client.doJsonRequest("DELETE", fmt.Sprintf("/v2/dashboard/lists/manual/%d/dashboards", dashboardListID), req, &out); err != nil {
+		return nil, err
+	}
+	return out.Dashboards, nil
+}

--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -4169,7 +4169,7 @@ func (d *DashboardListItem) SetType(v string) {
 }
 
 // GetID returns the ID field if non-nil, zero value otherwise.
-func (d *DashboardListV2Item) GetID() string {
+func (d *DashboardListItemV2) GetID() string {
 	if d == nil || d.ID == nil {
 		return ""
 	}
@@ -4178,7 +4178,7 @@ func (d *DashboardListV2Item) GetID() string {
 
 // GetIDOk returns a tuple with the ID field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (d *DashboardListV2Item) GetIDOk() (string, bool) {
+func (d *DashboardListItemV2) GetIDOk() (string, bool) {
 	if d == nil || d.ID == nil {
 		return "", false
 	}
@@ -4186,7 +4186,7 @@ func (d *DashboardListV2Item) GetIDOk() (string, bool) {
 }
 
 // HasID returns a boolean if a field has been set.
-func (d *DashboardListV2Item) HasID() bool {
+func (d *DashboardListItemV2) HasID() bool {
 	if d != nil && d.ID != nil {
 		return true
 	}
@@ -4195,12 +4195,12 @@ func (d *DashboardListV2Item) HasID() bool {
 }
 
 // SetID allocates a new d.ID and returns the pointer to it.
-func (d *DashboardListV2Item) SetID(v string) {
+func (d *DashboardListItemV2) SetID(v string) {
 	d.ID = &v
 }
 
 // GetType returns the Type field if non-nil, zero value otherwise.
-func (d *DashboardListV2Item) GetType() string {
+func (d *DashboardListItemV2) GetType() string {
 	if d == nil || d.Type == nil {
 		return ""
 	}
@@ -4209,7 +4209,7 @@ func (d *DashboardListV2Item) GetType() string {
 
 // GetTypeOk returns a tuple with the Type field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (d *DashboardListV2Item) GetTypeOk() (string, bool) {
+func (d *DashboardListItemV2) GetTypeOk() (string, bool) {
 	if d == nil || d.Type == nil {
 		return "", false
 	}
@@ -4217,7 +4217,7 @@ func (d *DashboardListV2Item) GetTypeOk() (string, bool) {
 }
 
 // HasType returns a boolean if a field has been set.
-func (d *DashboardListV2Item) HasType() bool {
+func (d *DashboardListItemV2) HasType() bool {
 	if d != nil && d.Type != nil {
 		return true
 	}
@@ -4226,7 +4226,7 @@ func (d *DashboardListV2Item) HasType() bool {
 }
 
 // SetType allocates a new d.Type and returns the pointer to it.
-func (d *DashboardListV2Item) SetType(v string) {
+func (d *DashboardListItemV2) SetType(v string) {
 	d.Type = &v
 }
 

--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -4168,6 +4168,68 @@ func (d *DashboardListItem) SetType(v string) {
 	d.Type = &v
 }
 
+// GetID returns the ID field if non-nil, zero value otherwise.
+func (d *DashboardListV2Item) GetID() string {
+	if d == nil || d.ID == nil {
+		return ""
+	}
+	return *d.ID
+}
+
+// GetIDOk returns a tuple with the ID field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (d *DashboardListV2Item) GetIDOk() (string, bool) {
+	if d == nil || d.ID == nil {
+		return "", false
+	}
+	return *d.ID, true
+}
+
+// HasID returns a boolean if a field has been set.
+func (d *DashboardListV2Item) HasID() bool {
+	if d != nil && d.ID != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetID allocates a new d.ID and returns the pointer to it.
+func (d *DashboardListV2Item) SetID(v string) {
+	d.ID = &v
+}
+
+// GetType returns the Type field if non-nil, zero value otherwise.
+func (d *DashboardListV2Item) GetType() string {
+	if d == nil || d.Type == nil {
+		return ""
+	}
+	return *d.Type
+}
+
+// GetTypeOk returns a tuple with the Type field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (d *DashboardListV2Item) GetTypeOk() (string, bool) {
+	if d == nil || d.Type == nil {
+		return "", false
+	}
+	return *d.Type, true
+}
+
+// HasType returns a boolean if a field has been set.
+func (d *DashboardListV2Item) HasType() bool {
+	if d != nil && d.Type != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetType allocates a new d.Type and returns the pointer to it.
+func (d *DashboardListV2Item) SetType(v string) {
+	d.Type = &v
+}
+
 // GetCreated returns the Created field if non-nil, zero value otherwise.
 func (d *DashboardLite) GetCreated() string {
 	if d == nil || d.Created == nil {

--- a/integration/dashboard_lists_v2_test.go
+++ b/integration/dashboard_lists_v2_test.go
@@ -23,11 +23,11 @@ func TestDashboardListItemsV2GetAndUpdate(t *testing.T) {
 	timeboard := createTestDashboard(t)
 	defer cleanUpDashboard(t, *timeboard.Id)
 
-	timeboardItems := []datadog.DashboardListV2Item{
+	timeboardItems := []datadog.DashboardListItemV2{
 		getTestDashboardListItemV2Timeboard(*timeboard.NewId),
 	}
 
-	actualItems, err := client.UpdateDashboardListV2Items(*list.Id, timeboardItems)
+	actualItems, err := client.UpdateDashboardListItemsV2(*list.Id, timeboardItems)
 	if err != nil {
 		t.Fatalf("Updating dashboard list items failed when it shouldn't: %s", err)
 	}
@@ -50,11 +50,11 @@ func TestDashboardListItemsV2GetAndUpdate(t *testing.T) {
 	screenboard := createTestScreenboard(t)
 	defer cleanUpScreenboard(t, *screenboard.Id)
 
-	screenboardItems := []datadog.DashboardListV2Item{
+	screenboardItems := []datadog.DashboardListItemV2{
 		getTestDashboardListItemV2Screenboard(*screenboard.NewId),
 	}
 
-	actualItems, err = client.UpdateDashboardListV2Items(*list.Id, screenboardItems)
+	actualItems, err = client.UpdateDashboardListItemsV2(*list.Id, screenboardItems)
 	if err != nil {
 		t.Fatalf("Updating dashboard list items failed when it shouldn't: %s", err)
 	}
@@ -87,11 +87,11 @@ func TestDashboardListItemsV2AddAndDelete(t *testing.T) {
 	timeboard := createTestDashboard(t)
 	defer cleanUpDashboard(t, *timeboard.Id)
 
-	items := []datadog.DashboardListV2Item{
+	items := []datadog.DashboardListItemV2{
 		getTestDashboardListItemV2Timeboard(*timeboard.NewId),
 	}
 
-	addedItems, err := client.AddDashboardListV2Items(*list.Id, items)
+	addedItems, err := client.AddDashboardListItemsV2(*list.Id, items)
 	if err != nil {
 		t.Fatalf("Adding dashboard list items failed when it shouldn't: %s", err)
 	}
@@ -117,7 +117,7 @@ func TestDashboardListItemsV2AddAndDelete(t *testing.T) {
 
 	items = append(items, getTestDashboardListItemV2Screenboard(*screenboard.NewId))
 
-	addedItems, err = client.AddDashboardListV2Items(*list.Id, items)
+	addedItems, err = client.AddDashboardListItemsV2(*list.Id, items)
 	if err != nil {
 		t.Fatalf("Adding dashboard list items failed when it shouldn't: %s", err)
 	}
@@ -137,7 +137,7 @@ func TestDashboardListItemsV2AddAndDelete(t *testing.T) {
 	}
 
 	// Delete everything in the dashboard list and check length of deleted items is 2
-	deletedItems, err := client.DeleteDashboardListV2Items(*list.Id, items)
+	deletedItems, err := client.DeleteDashboardListItemsV2(*list.Id, items)
 	if err != nil {
 		t.Fatalf("Deleting dashboard list items failed when it shouldn't: %s", err)
 	}
@@ -156,14 +156,14 @@ func TestDashboardListItemsV2AddAndDelete(t *testing.T) {
 	}
 }
 
-func getTestDashboardListItemV2Timeboard(id string) datadog.DashboardListV2Item {
-	return datadog.DashboardListV2Item{
+func getTestDashboardListItemV2Timeboard(id string) datadog.DashboardListItemV2 {
+	return datadog.DashboardListItemV2{
 		ID:   datadog.String(id),
 		Type: datadog.String(datadog.DashboardListItemCustomTimeboard),
 	}
 }
 
-func assertDashboardListItemV2Equals(t *testing.T, actual, expected *datadog.DashboardListV2Item) {
+func assertDashboardListItemV2Equals(t *testing.T, actual, expected *datadog.DashboardListItemV2) {
 	if *actual.ID != *expected.ID {
 		t.Errorf("Dashboard list item id does not match: %s != %s", *actual.ID, *expected.ID)
 	}
@@ -172,8 +172,8 @@ func assertDashboardListItemV2Equals(t *testing.T, actual, expected *datadog.Das
 	}
 }
 
-func getTestDashboardListItemV2Screenboard(id string) datadog.DashboardListV2Item {
-	return datadog.DashboardListV2Item{
+func getTestDashboardListItemV2Screenboard(id string) datadog.DashboardListItemV2 {
+	return datadog.DashboardListItemV2{
 		ID:   datadog.String(id),
 		Type: datadog.String(datadog.DashboardListItemCustomScreenboard),
 	}

--- a/integration/dashboard_lists_v2_test.go
+++ b/integration/dashboard_lists_v2_test.go
@@ -1,0 +1,180 @@
+package integration
+
+import (
+	"testing"
+
+	datadog "github.com/zorkian/go-datadog-api"
+)
+
+func TestDashboardListItemsV2GetAndUpdate(t *testing.T) {
+	list := getTestDashboardList()
+	list, err := client.CreateDashboardList(list)
+	if err != nil {
+		t.Fatalf("Creating a dashboard list failed when it shouldn't: %s", err)
+	}
+
+	defer cleanUpDashboardList(t, *list.Id)
+
+	if *list.DashboardCount != 0 {
+		t.Fatalf("Number of dashboards in dashboard list does not match: %d != %d", *list.DashboardCount, 0)
+	}
+
+	// Test update with timeboard in list
+	timeboard := createTestDashboard(t)
+	defer cleanUpDashboard(t, *timeboard.Id)
+
+	timeboardItems := []datadog.DashboardListV2Item{
+		getTestDashboardListItemV2Timeboard(*timeboard.NewId),
+	}
+
+	actualItems, err := client.UpdateDashboardListV2Items(*list.Id, timeboardItems)
+	if err != nil {
+		t.Fatalf("Updating dashboard list items failed when it shouldn't: %s", err)
+	}
+	if len(actualItems) != len(timeboardItems) {
+		t.Fatalf("Number of updated dashboards does not match: %d != %d", len(actualItems), len(timeboardItems))
+	}
+	assertDashboardListItemV2Equals(t, &actualItems[0], &timeboardItems[0])
+
+	// Get dashboard list to make sure count is 1
+	list, err = client.GetDashboardList(*list.Id)
+	if err != nil {
+		t.Fatalf("Getting a dashboard list failed when it shouldn't: %s", err)
+	}
+
+	if *list.DashboardCount != len(timeboardItems) {
+		t.Fatalf("Number of dashboards in dashboard list does not match: %d != %d", *list.DashboardCount, 0)
+	}
+
+	// Test update with screenboard in list
+	screenboard := createTestScreenboard(t)
+	defer cleanUpScreenboard(t, *screenboard.Id)
+
+	screenboardItems := []datadog.DashboardListV2Item{
+		getTestDashboardListItemV2Screenboard(*screenboard.NewId),
+	}
+
+	actualItems, err = client.UpdateDashboardListV2Items(*list.Id, screenboardItems)
+	if err != nil {
+		t.Fatalf("Updating dashboard list items failed when it shouldn't: %s", err)
+	}
+	if len(actualItems) != len(screenboardItems) {
+		t.Fatalf("Number of updated dashboards does not match: %d != %d", len(actualItems), len(screenboardItems))
+	}
+	assertDashboardListItemV2Equals(t, &actualItems[0], &screenboardItems[0])
+
+	// Get dashboard list to make sure count is 1
+	list, err = client.GetDashboardList(*list.Id)
+	if err != nil {
+		t.Fatalf("Getting a dashboard list failed when it shouldn't: %s", err)
+	}
+
+	if *list.DashboardCount != len(screenboardItems) {
+		t.Fatalf("Number of dashboards in dashboard list does not match: %d != %d", *list.DashboardCount, 0)
+	}
+}
+
+func TestDashboardListItemsV2AddAndDelete(t *testing.T) {
+	list := getTestDashboardList()
+	list, err := client.CreateDashboardList(list)
+	if err != nil {
+		t.Fatalf("Creating a dashboard list failed when it shouldn't: %s", err)
+	}
+
+	defer cleanUpDashboardList(t, *list.Id)
+
+	// Add timeboard to list
+	timeboard := createTestDashboard(t)
+	defer cleanUpDashboard(t, *timeboard.Id)
+
+	items := []datadog.DashboardListV2Item{
+		getTestDashboardListItemV2Timeboard(*timeboard.NewId),
+	}
+
+	addedItems, err := client.AddDashboardListV2Items(*list.Id, items)
+	if err != nil {
+		t.Fatalf("Adding dashboard list items failed when it shouldn't: %s", err)
+	}
+	if len(addedItems) != len(items) {
+		t.Fatalf("Number of updated dashboards does not match: %d != %d", len(addedItems), len(items))
+	}
+	assertDashboardListItemV2Equals(t, &addedItems[0], &items[0])
+
+	// Get dashboard list to make sure count is 1
+	list, err = client.GetDashboardList(*list.Id)
+	if err != nil {
+		t.Fatalf("Getting a dashboard list failed when it shouldn't: %s", err)
+	}
+
+	if *list.DashboardCount != len(items) {
+		t.Fatalf("Number of dashboards in dashboard list does not match: %d != %d", *list.DashboardCount, 0)
+	}
+
+	// Adding an existing item should be ignored, meaning we should only get
+	// one item back in the list of added items.
+	screenboard := createTestScreenboard(t)
+	defer cleanUpScreenboard(t, *screenboard.Id)
+
+	items = append(items, getTestDashboardListItemV2Screenboard(*screenboard.NewId))
+
+	addedItems, err = client.AddDashboardListV2Items(*list.Id, items)
+	if err != nil {
+		t.Fatalf("Adding dashboard list items failed when it shouldn't: %s", err)
+	}
+	if len(addedItems) != 1 {
+		t.Fatalf("Number of updated dashboards does not match: %d != %d", len(addedItems), 1)
+	}
+	assertDashboardListItemV2Equals(t, &addedItems[0], &items[1])
+
+	// Get dashboard list to make sure count is now 2
+	list, err = client.GetDashboardList(*list.Id)
+	if err != nil {
+		t.Fatalf("Getting a dashboard list failed when it shouldn't: %s", err)
+	}
+
+	if *list.DashboardCount != len(items) {
+		t.Fatalf("Number of dashboards in dashboard list does not match: %d != %d", *list.DashboardCount, 0)
+	}
+
+	// Delete everything in the dashboard list and check length of deleted items is 2
+	deletedItems, err := client.DeleteDashboardListV2Items(*list.Id, items)
+	if err != nil {
+		t.Fatalf("Deleting dashboard list items failed when it shouldn't: %s", err)
+	}
+	if len(deletedItems) != len(items) {
+		t.Fatalf("Number of deleted dashboards does not match: %d != %d", len(deletedItems), len(items))
+	}
+
+	// Check that the dashboard list is empty again
+	list, err = client.GetDashboardList(*list.Id)
+	if err != nil {
+		t.Fatalf("Getting a dashboard list failed when it shouldn't: %s", err)
+	}
+
+	if *list.DashboardCount != 0 {
+		t.Fatalf("Number of dashboards in dashboard list does not match: %d != %d", *list.DashboardCount, 0)
+	}
+}
+
+func getTestDashboardListItemV2Timeboard(id string) datadog.DashboardListV2Item {
+	return datadog.DashboardListV2Item{
+		ID:   datadog.String(id),
+		Type: datadog.String(datadog.DashboardListItemCustomTimeboard),
+	}
+}
+
+func assertDashboardListItemV2Equals(t *testing.T, actual, expected *datadog.DashboardListV2Item) {
+	if *actual.ID != *expected.ID {
+		t.Errorf("Dashboard list item id does not match: %s != %s", *actual.ID, *expected.ID)
+	}
+	if *actual.Type != *expected.Type {
+		t.Errorf("Dashboard list item type does not match: %s != %s", *actual.Type, *expected.Type)
+	}
+}
+
+func getTestDashboardListItemV2Screenboard(id string) datadog.DashboardListV2Item {
+	return datadog.DashboardListV2Item{
+		ID:   datadog.String(id),
+		Type: datadog.String(datadog.DashboardListItemCustomScreenboard),
+	}
+}


### PR DESCRIPTION
Adds the v2 version of the dashboard list item API - https://docs.datadoghq.com/api/?lang=python#get-items-of-a-dashboard-list

Makes new methods for each CRUD operation (same names as the V1 version but appended with `V2`)

Only the individual items API has a V2, so this doesn't duplicate the V1 dashboard_list API. Mostly the same, but the Item struct `ID` field is now all capitalized, and returns a string instead of an integer. 