### PR TITLE
Add test for app keys

### DIFF
--- a/app_keys_test.go
+++ b/app_keys_test.go
@@ -1,0 +1,34 @@
+/*
+ * Datadog API for Go
+ *
+ * Please see the included LICENSE file for licensing information.
+ *
+ * Copyright 2019 by authors and contributors.
+ */
+
+package datadog_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	dd "github.com/zorkian/go-datadog-api"
+)
+
+func TestAPPKeySerialization(t *testing.T) {
+
+	raw := `
+	{
+		"owner": "john@example.com",
+		"name": "myCoolKey",
+		"hash": "31111111111111111111aaaaaaaaaaaaaaaaaaaa"
+	}`
+
+	var appkey dd.APPKey
+	err := json.Unmarshal([]byte(raw), &appkey)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, *appkey.Name, "myCoolKey")
+	assert.Equal(t, *appkey.Owner, "john@example.com")
+	assert.Equal(t, *appkey.Hash, "31111111111111111111aaaaaaaaaaaaaaaaaaaa")
+}


### PR DESCRIPTION
Similar to `app_keys_test.go`, using example from https://docs.datadoghq.com/api/?lang=bash#get-an-application-key