### PR TITLE
Add Webhooks Integration support

### DIFF
--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -23569,6 +23569,156 @@ func (u *UserAgentParser) HasIsEncoded() bool {
 	return false
 }
 
+// GetCustomPayload returns the CustomPayload field if non-nil, zero value otherwise.
+func (w *Webhook) GetCustomPayload() string {
+	if w == nil || w.CustomPayload == nil {
+		return ""
+	}
+	return *w.CustomPayload
+}
+
+// GetCustomPayloadOk returns a tuple with the CustomPayload field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Webhook) GetCustomPayloadOk() (string, bool) {
+	if w == nil || w.CustomPayload == nil {
+		return "", false
+	}
+	return *w.CustomPayload, true
+}
+
+// HasCustomPayload returns a boolean if a field has been set.
+func (w *Webhook) HasCustomPayload() bool {
+	if w != nil && w.CustomPayload != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCustomPayload allocates a new w.CustomPayload and returns the pointer to it.
+func (w *Webhook) SetCustomPayload(v string) {
+	w.CustomPayload = &v
+}
+
+// GetEncodeAsForm returns the EncodeAsForm field if non-nil, zero value otherwise.
+func (w *Webhook) GetEncodeAsForm() string {
+	if w == nil || w.EncodeAsForm == nil {
+		return ""
+	}
+	return *w.EncodeAsForm
+}
+
+// GetEncodeAsFormOk returns a tuple with the EncodeAsForm field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Webhook) GetEncodeAsFormOk() (string, bool) {
+	if w == nil || w.EncodeAsForm == nil {
+		return "", false
+	}
+	return *w.EncodeAsForm, true
+}
+
+// HasEncodeAsForm returns a boolean if a field has been set.
+func (w *Webhook) HasEncodeAsForm() bool {
+	if w != nil && w.EncodeAsForm != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetEncodeAsForm allocates a new w.EncodeAsForm and returns the pointer to it.
+func (w *Webhook) SetEncodeAsForm(v string) {
+	w.EncodeAsForm = &v
+}
+
+// GetHeaders returns the Headers field if non-nil, zero value otherwise.
+func (w *Webhook) GetHeaders() string {
+	if w == nil || w.Headers == nil {
+		return ""
+	}
+	return *w.Headers
+}
+
+// GetHeadersOk returns a tuple with the Headers field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Webhook) GetHeadersOk() (string, bool) {
+	if w == nil || w.Headers == nil {
+		return "", false
+	}
+	return *w.Headers, true
+}
+
+// HasHeaders returns a boolean if a field has been set.
+func (w *Webhook) HasHeaders() bool {
+	if w != nil && w.Headers != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetHeaders allocates a new w.Headers and returns the pointer to it.
+func (w *Webhook) SetHeaders(v string) {
+	w.Headers = &v
+}
+
+// GetName returns the Name field if non-nil, zero value otherwise.
+func (w *Webhook) GetName() string {
+	if w == nil || w.Name == nil {
+		return ""
+	}
+	return *w.Name
+}
+
+// GetNameOk returns a tuple with the Name field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Webhook) GetNameOk() (string, bool) {
+	if w == nil || w.Name == nil {
+		return "", false
+	}
+	return *w.Name, true
+}
+
+// HasName returns a boolean if a field has been set.
+func (w *Webhook) HasName() bool {
+	if w != nil && w.Name != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetName allocates a new w.Name and returns the pointer to it.
+func (w *Webhook) SetName(v string) {
+	w.Name = &v
+}
+
+// GetURL returns the URL field if non-nil, zero value otherwise.
+func (w *Webhook) GetURL() string {
+	if w == nil || w.URL == nil {
+		return ""
+	}
+	return *w.URL
+}
+
+// GetURLOk returns a tuple with the URL field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Webhook) GetURLOk() (string, bool) {
+	if w == nil || w.URL == nil {
+		return "", false
+	}
+	return *w.URL, true
+}
+
+// HasURL returns a boolean if a field has been set.
+func (w *Webhook) HasURL() bool {
+	if w != nil && w.URL != nil {
+		return true
+	}
+
+	return false
+}
+
 // SetIsEncoded allocates a new u.IsEncoded and returns the pointer to it.
 func (u *UserAgentParser) SetIsEncoded(v bool) {
 	u.IsEncoded = &v
@@ -23600,9 +23750,45 @@ func (u *UserAgentParser) HasTarget() bool {
 	return false
 }
 
+// SetURL allocates a new w.URL and returns the pointer to it.
+func (w *Webhook) SetURL(v string) {
+	w.URL = &v
+}
+
+// GetUseCustomPayload returns the UseCustomPayload field if non-nil, zero value otherwise.
+func (w *Webhook) GetUseCustomPayload() string {
+	if w == nil || w.UseCustomPayload == nil {
+		return ""
+	}
+	return *w.UseCustomPayload
+}
+
+// GetUseCustomPayloadOk returns a tuple with the UseCustomPayload field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Webhook) GetUseCustomPayloadOk() (string, bool) {
+	if w == nil || w.UseCustomPayload == nil {
+		return "", false
+	}
+	return *w.UseCustomPayload, true
+}
+
+// HasUseCustomPayload returns a boolean if a field has been set.
+func (w *Webhook) HasUseCustomPayload() bool {
+	if w != nil && w.UseCustomPayload != nil {
+		return true
+	}
+
+	return false
+}
+
 // SetTarget allocates a new u.Target and returns the pointer to it.
 func (u *UserAgentParser) SetTarget(v string) {
 	u.Target = &v
+}
+
+// SetUseCustomPayload allocates a new w.UseCustomPayload and returns the pointer to it.
+func (w *Webhook) SetUseCustomPayload(v string) {
+	w.UseCustomPayload = &v
 }
 
 // GetAlertID returns the AlertID field if non-nil, zero value otherwise.

--- a/integration/integrations_test.go
+++ b/integration/integrations_test.go
@@ -294,6 +294,130 @@ func cleanUpIntegrationSlack(t *testing.T) {
 }
 
 /*
+	Webhook Integration
+*/
+
+func TestIntegrationWebhookCreateAndDelete(t *testing.T) {
+	expected := createTestIntegrationWebhook(t)
+	defer cleanUpIntegrationWebhook(t)
+
+	actual, err := client.GetIntegrationWebhook()
+	if err != nil {
+		t.Fatalf("Retrieving a Webhook integration failed when it shouldn't: (%s)", err)
+	}
+
+	expectedWebhooks := make([]*string, len(expected.Webhooks))
+	for _, wh := range expected.Webhooks {
+		expectedWebhooks = append(expectedWebhooks, wh.Name)
+	}
+
+	actualWebhooks := make([]*string, len(actual.Webhooks))
+	for _, wh := range actual.Webhooks {
+		actualWebhooks = append(actualWebhooks, wh.Name)
+	}
+
+	assert.Equal(t, expectedWebhooks, actualWebhooks)
+}
+
+func TestIntegrationWebhookUpdate(t *testing.T) {
+	webhookIntegration := createTestIntegrationWebhook(t)
+	defer cleanUpIntegrationWebhook(t)
+
+	webhookIntegration.Webhooks = append(webhookIntegration.Webhooks, datadog.Webhook{
+		Name:             datadog.String("Test_Webhook2"),
+		URL:              datadog.String("https://test.url.com/webhook"),
+		UseCustomPayload: datadog.String("true"),
+		CustomPayload:    datadog.String("custom_payload"),
+		EncodeAsForm:     datadog.String("true"),
+		Headers:          datadog.String("{'Content-Type': 'application/text', 'Authorization': 'token'}"),
+	})
+
+	if err := client.UpdateIntegrationWebhook(webhookIntegration); err != nil {
+		t.Fatalf("Updating a Webhook integration failed when it shouldn't: %s", err)
+	}
+
+	actual, err := client.GetIntegrationWebhook()
+	if err != nil {
+		t.Fatalf("Retrieving a Webhook integration failed when it shouldn't: %s", err)
+	}
+
+	expectedWebhooks := make([]*string, len(webhookIntegration.Webhooks))
+	for _, wh := range webhookIntegration.Webhooks {
+		expectedWebhooks = append(expectedWebhooks, wh.Name)
+	}
+
+	actualWebhooks := make([]*string, len(actual.Webhooks))
+	for _, wh := range actual.Webhooks {
+		actualWebhooks = append(actualWebhooks, wh.Name)
+	}
+
+	assert.Equal(t, expectedWebhooks, actualWebhooks)
+}
+
+func TestIntegrationWebhookGet(t *testing.T) {
+	webhookIntegration := createTestIntegrationWebhook(t)
+	defer cleanUpIntegrationWebhook(t)
+
+	actual, err := client.GetIntegrationWebhook()
+	if err != nil {
+		t.Fatalf("Retrieving Webhook integration failed when it shouldn't: %s", err)
+	}
+
+	expectedWebhooks := make([]*string, len(webhookIntegration.Webhooks))
+	for _, wh := range webhookIntegration.Webhooks {
+		expectedWebhooks = append(expectedWebhooks, wh.Name)
+	}
+
+	actualWebhooks := make([]*string, len(actual.Webhooks))
+	for _, wh := range actual.Webhooks {
+		actualWebhooks = append(actualWebhooks, wh.Name)
+	}
+
+	assert.Equal(t, expectedWebhooks, actualWebhooks)
+}
+
+func getTestIntegrationWebhook() *datadog.IntegrationWebhookRequest {
+	return &datadog.IntegrationWebhookRequest{
+		Webhooks: []datadog.Webhook{
+			{
+				Name:             datadog.String("Test_Webhook1"),
+				URL:              datadog.String("https://test.url.com/webhook"),
+				UseCustomPayload: datadog.String("true"),
+				CustomPayload:    datadog.String("custom_payload"),
+				EncodeAsForm:     datadog.String("true"),
+				Headers:          datadog.String("{'Content-Type': 'application/text', 'Authorization': 'token'}"),
+			},
+		},
+	}
+}
+
+func createTestIntegrationWebhook(t *testing.T) *datadog.IntegrationWebhookRequest {
+	webhookIntegration := getTestIntegrationWebhook()
+
+	err := client.CreateIntegrationWebhook(webhookIntegration)
+	if err != nil {
+		t.Fatalf("Creating a Webhook integration failed when it shouldn't: %s", err)
+	}
+
+	return webhookIntegration
+}
+
+func cleanUpIntegrationWebhook(t *testing.T) {
+	if err := client.DeleteIntegrationWebhook(); err != nil {
+		t.Fatalf("Deleting the Webhook integration failed when it shouldn't. Manual cleanup needed. (%s)", err)
+	}
+
+	webhookIntegration, err := client.GetIntegrationWebhook()
+	if webhookIntegration != nil {
+		t.Fatal("Webhook Integration hasn't been deleted when it should have been. Manual cleanup needed.")
+	}
+
+	if err == nil {
+		t.Fatal("Fetching deleted Webhook integration didn't lead to an error.")
+	}
+}
+
+/*
 	AWS Integration
 */
 

--- a/integrations.go
+++ b/integrations.go
@@ -159,6 +159,52 @@ func (client *Client) DeleteIntegrationSlack() error {
 }
 
 /*
+	Webhook Integration
+*/
+
+// IntegrationWebhookRequest defines the structure of the a webhook request
+type IntegrationWebhookRequest struct {
+	Webhooks []Webhook `json:"hooks"`
+}
+
+// Webhook defines the structure of the a webhook
+type Webhook struct {
+	Name             *string `json:"name"`
+	URL              *string `json:"url"`
+	UseCustomPayload *string `json:"use_custom_payload"`
+	CustomPayload    *string `json:"custom_payload"`
+	EncodeAsForm     *string `json:"encode_as_form"`
+	Headers          *string `json:"headers"`
+}
+
+// CreateIntegrationWebhook creates new webhook integration object(s).
+func (client *Client) CreateIntegrationWebhook(webhookIntegration *IntegrationWebhookRequest) error {
+	return client.doJsonRequest("POST", "/v1/integration/webhooks", webhookIntegration, nil)
+}
+
+// UpdateIntegrationWebhook updates the Webhook Integration.
+// It replaces the existing configuration with the configuration sent in this
+// request.
+func (client *Client) UpdateIntegrationWebhook(webhookIntegration *IntegrationWebhookRequest) error {
+	return client.doJsonRequest("PUT", "/v1/integration/webhooks", webhookIntegration, nil)
+}
+
+// GetIntegrationWebhook gets all the Webhook Integrations from Datadog.
+func (client *Client) GetIntegrationWebhook() (*IntegrationWebhookRequest, error) {
+	var out IntegrationWebhookRequest
+	if err := client.doJsonRequest("GET", "/v1/integration/webhooks", nil, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+// DeleteIntegrationWebhook removes the Webhook Integration from Datadog.
+func (client *Client) DeleteIntegrationWebhook() error {
+	return client.doJsonRequest("DELETE", "/v1/integration/webhooks", nil, nil)
+}
+
+/*
 	AWS Integration
 */
 


### PR DESCRIPTION
This PR adds support for Webhooks Integration to the library.

Integration Tests:

```
$ export DATADOG_API_KEY="XXX"
$ export DATADOG_APP_KEY="YYY"

$ make testacc TESTARGS='-run=TestIntegrationWebhookCreateAndDelete'
go test integration/* -v -run=TestIntegrationWebhookCreateAndDelete -timeout 90m
=== RUN   TestIntegrationWebhookCreateAndDelete
--- PASS: TestIntegrationWebhookCreateAndDelete (1.39s)
PASS
ok      command-line-arguments  (cached)

$ make testacc TESTARGS='-run=TestIntegrationWebhookUpdate'
go test integration/* -v -run=TestIntegrationWebhookUpdate -timeout 90m
=== RUN   TestIntegrationWebhookUpdate
--- PASS: TestIntegrationWebhookUpdate (1.61s)
PASS
ok      command-line-arguments  (cached)

$ make testacc TESTARGS='-run=TestIntegrationWebhookGet'
go test integration/* -v -run=TestIntegrationWebhookGet -timeout 90m
=== RUN   TestIntegrationWebhookGet
--- PASS: TestIntegrationWebhookGet (1.17s)
PASS
ok      command-line-arguments  (cached)
```