### PR TITLE
Support logs index API

### DIFF
--- a/cmd/tools/gen-accessors.go
+++ b/cmd/tools/gen-accessors.go
@@ -175,7 +175,7 @@ func newAccessor(receiverType, fieldName, fieldType, zeroValue string) *accessor
 func (t *templateData) addIdent(x *ast.Ident, receiverType, fieldName string) {
 	var zeroValue string
 	switch x.String() {
-	case "int":
+	case "int", "int64":
 		zeroValue = "0"
 	case "string":
 		zeroValue = `""`

--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -6338,6 +6338,161 @@ func (e *EventTimelineDefinition) SetType(v string) {
 	e.Type = &v
 }
 
+// GetFilter returns the Filter field if non-nil, zero value otherwise.
+func (e *ExclusionFilter) GetFilter() Filter {
+	if e == nil || e.Filter == nil {
+		return Filter{}
+	}
+	return *e.Filter
+}
+
+// GetFilterOk returns a tuple with the Filter field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (e *ExclusionFilter) GetFilterOk() (Filter, bool) {
+	if e == nil || e.Filter == nil {
+		return Filter{}, false
+	}
+	return *e.Filter, true
+}
+
+// HasFilter returns a boolean if a field has been set.
+func (e *ExclusionFilter) HasFilter() bool {
+	if e != nil && e.Filter != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetFilter allocates a new e.Filter and returns the pointer to it.
+func (e *ExclusionFilter) SetFilter(v Filter) {
+	e.Filter = &v
+}
+
+// GetIsEnabled returns the IsEnabled field if non-nil, zero value otherwise.
+func (e *ExclusionFilter) GetIsEnabled() bool {
+	if e == nil || e.IsEnabled == nil {
+		return false
+	}
+	return *e.IsEnabled
+}
+
+// GetIsEnabledOk returns a tuple with the IsEnabled field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (e *ExclusionFilter) GetIsEnabledOk() (bool, bool) {
+	if e == nil || e.IsEnabled == nil {
+		return false, false
+	}
+	return *e.IsEnabled, true
+}
+
+// HasIsEnabled returns a boolean if a field has been set.
+func (e *ExclusionFilter) HasIsEnabled() bool {
+	if e != nil && e.IsEnabled != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetIsEnabled allocates a new e.IsEnabled and returns the pointer to it.
+func (e *ExclusionFilter) SetIsEnabled(v bool) {
+	e.IsEnabled = &v
+}
+
+// GetName returns the Name field if non-nil, zero value otherwise.
+func (e *ExclusionFilter) GetName() string {
+	if e == nil || e.Name == nil {
+		return ""
+	}
+	return *e.Name
+}
+
+// GetNameOk returns a tuple with the Name field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (e *ExclusionFilter) GetNameOk() (string, bool) {
+	if e == nil || e.Name == nil {
+		return "", false
+	}
+	return *e.Name, true
+}
+
+// HasName returns a boolean if a field has been set.
+func (e *ExclusionFilter) HasName() bool {
+	if e != nil && e.Name != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetName allocates a new e.Name and returns the pointer to it.
+func (e *ExclusionFilter) SetName(v string) {
+	e.Name = &v
+}
+
+// GetQuery returns the Query field if non-nil, zero value otherwise.
+func (f *Filter) GetQuery() string {
+	if f == nil || f.Query == nil {
+		return ""
+	}
+	return *f.Query
+}
+
+// GetQueryOk returns a tuple with the Query field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (f *Filter) GetQueryOk() (string, bool) {
+	if f == nil || f.Query == nil {
+		return "", false
+	}
+	return *f.Query, true
+}
+
+// HasQuery returns a boolean if a field has been set.
+func (f *Filter) HasQuery() bool {
+	if f != nil && f.Query != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetQuery allocates a new f.Query and returns the pointer to it.
+func (f *Filter) SetQuery(v string) {
+	f.Query = &v
+}
+
+// GetSampleRate returns the SampleRate field if non-nil, zero value otherwise.
+func (f *Filter) GetSampleRate() float64 {
+	if f == nil || f.SampleRate == nil {
+		return 0
+	}
+	return *f.SampleRate
+}
+
+// GetSampleRateOk returns a tuple with the SampleRate field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (f *Filter) GetSampleRateOk() (float64, bool) {
+	if f == nil || f.SampleRate == nil {
+		return 0, false
+	}
+	return *f.SampleRate, true
+}
+
+// HasSampleRate returns a boolean if a field has been set.
+func (f *Filter) HasSampleRate() bool {
+	if f != nil && f.SampleRate != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSampleRate allocates a new f.SampleRate and returns the pointer to it.
+func (f *Filter) SetSampleRate(v float64) {
+	f.SampleRate = &v
+}
+
 // GetQuery returns the Query field if non-nil, zero value otherwise.
 func (f *FilterConfiguration) GetQuery() string {
 	if f == nil || f.Query == nil {
@@ -10769,6 +10924,161 @@ func (l *LogSet) HasName() bool {
 // SetName allocates a new l.Name and returns the pointer to it.
 func (l *LogSet) SetName(v string) {
 	l.Name = &v
+}
+
+// GetDailyLimit returns the DailyLimit field if non-nil, zero value otherwise.
+func (l *LogsIndex) GetDailyLimit() int64 {
+	if l == nil || l.DailyLimit == nil {
+		return 0
+	}
+	return *l.DailyLimit
+}
+
+// GetDailyLimitOk returns a tuple with the DailyLimit field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (l *LogsIndex) GetDailyLimitOk() (int64, bool) {
+	if l == nil || l.DailyLimit == nil {
+		return 0, false
+	}
+	return *l.DailyLimit, true
+}
+
+// HasDailyLimit returns a boolean if a field has been set.
+func (l *LogsIndex) HasDailyLimit() bool {
+	if l != nil && l.DailyLimit != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetDailyLimit allocates a new l.DailyLimit and returns the pointer to it.
+func (l *LogsIndex) SetDailyLimit(v int64) {
+	l.DailyLimit = &v
+}
+
+// GetFilter returns the Filter field if non-nil, zero value otherwise.
+func (l *LogsIndex) GetFilter() FilterConfiguration {
+	if l == nil || l.Filter == nil {
+		return FilterConfiguration{}
+	}
+	return *l.Filter
+}
+
+// GetFilterOk returns a tuple with the Filter field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (l *LogsIndex) GetFilterOk() (FilterConfiguration, bool) {
+	if l == nil || l.Filter == nil {
+		return FilterConfiguration{}, false
+	}
+	return *l.Filter, true
+}
+
+// HasFilter returns a boolean if a field has been set.
+func (l *LogsIndex) HasFilter() bool {
+	if l != nil && l.Filter != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetFilter allocates a new l.Filter and returns the pointer to it.
+func (l *LogsIndex) SetFilter(v FilterConfiguration) {
+	l.Filter = &v
+}
+
+// GetIsRateLimited returns the IsRateLimited field if non-nil, zero value otherwise.
+func (l *LogsIndex) GetIsRateLimited() bool {
+	if l == nil || l.IsRateLimited == nil {
+		return false
+	}
+	return *l.IsRateLimited
+}
+
+// GetIsRateLimitedOk returns a tuple with the IsRateLimited field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (l *LogsIndex) GetIsRateLimitedOk() (bool, bool) {
+	if l == nil || l.IsRateLimited == nil {
+		return false, false
+	}
+	return *l.IsRateLimited, true
+}
+
+// HasIsRateLimited returns a boolean if a field has been set.
+func (l *LogsIndex) HasIsRateLimited() bool {
+	if l != nil && l.IsRateLimited != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetIsRateLimited allocates a new l.IsRateLimited and returns the pointer to it.
+func (l *LogsIndex) SetIsRateLimited(v bool) {
+	l.IsRateLimited = &v
+}
+
+// GetName returns the Name field if non-nil, zero value otherwise.
+func (l *LogsIndex) GetName() string {
+	if l == nil || l.Name == nil {
+		return ""
+	}
+	return *l.Name
+}
+
+// GetNameOk returns a tuple with the Name field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (l *LogsIndex) GetNameOk() (string, bool) {
+	if l == nil || l.Name == nil {
+		return "", false
+	}
+	return *l.Name, true
+}
+
+// HasName returns a boolean if a field has been set.
+func (l *LogsIndex) HasName() bool {
+	if l != nil && l.Name != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetName allocates a new l.Name and returns the pointer to it.
+func (l *LogsIndex) SetName(v string) {
+	l.Name = &v
+}
+
+// GetNumRetentionDays returns the NumRetentionDays field if non-nil, zero value otherwise.
+func (l *LogsIndex) GetNumRetentionDays() int64 {
+	if l == nil || l.NumRetentionDays == nil {
+		return 0
+	}
+	return *l.NumRetentionDays
+}
+
+// GetNumRetentionDaysOk returns a tuple with the NumRetentionDays field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (l *LogsIndex) GetNumRetentionDaysOk() (int64, bool) {
+	if l == nil || l.NumRetentionDays == nil {
+		return 0, false
+	}
+	return *l.NumRetentionDays, true
+}
+
+// HasNumRetentionDays returns a boolean if a field has been set.
+func (l *LogsIndex) HasNumRetentionDays() bool {
+	if l != nil && l.NumRetentionDays != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetNumRetentionDays allocates a new l.NumRetentionDays and returns the pointer to it.
+func (l *LogsIndex) SetNumRetentionDays(v int64) {
+	l.NumRetentionDays = &v
 }
 
 // GetFilter returns the Filter field if non-nil, zero value otherwise.

--- a/helpers.go
+++ b/helpers.go
@@ -33,6 +33,10 @@ func GetBool(v *bool) (bool, bool) {
 // to store v and returns a pointer to it.
 func Int(v int) *int { return &v }
 
+// Int64 is a helper routine that allocates a new int64 value to
+// store v and return a pointer to it.
+func Int64(v int64) *int64 { return &v }
+
 // GetIntOk is a helper routine that returns a boolean representing
 // if a value was set, and if so, dereferences the pointer to it.
 func GetIntOk(v *int) (int, bool) {

--- a/integration/logs_indexes_test.go
+++ b/integration/logs_indexes_test.go
@@ -1,0 +1,82 @@
+package integration
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/zorkian/go-datadog-api"
+	"testing"
+)
+
+func TestLogsIndexGet(t *testing.T) {
+	logsIndex, err := client.GetLogsIndex("main")
+	assert.Nil(t, err)
+
+	updateLogsIndex := datadog.LogsIndex{
+		Filter: &datadog.FilterConfiguration{Query: datadog.String("updated query")},
+		ExclusionFilters: []datadog.ExclusionFilter{
+			{
+				Name:      datadog.String("updated Filter 1"),
+				IsEnabled: datadog.Bool(false),
+				Filter: &datadog.Filter{
+					Query:      datadog.String("source:agent"),
+					SampleRate: datadog.Float64(0.3),
+				},
+			}, {
+				Name:      datadog.String("updated Filter 2"),
+				IsEnabled: datadog.Bool(false),
+				Filter: &datadog.Filter{
+					Query:      datadog.String("source:info"),
+					SampleRate: datadog.Float64(0.2),
+				},
+			}, {
+				Name:      datadog.String("updated Filter 3"),
+				IsEnabled: datadog.Bool(false),
+				Filter: &datadog.Filter{
+					Query:      datadog.String("source:warn"),
+					SampleRate: datadog.Float64(1.0),
+				},
+			},
+		},
+	}
+	updatedLogsIndex, err := client.UpdateLogsIndex(*logsIndex.Name, &updateLogsIndex)
+	defer assertRevertChange(t, logsIndex)
+	assert.Nil(t, err)
+	assert.Equal(t, &datadog.LogsIndex{
+		Name:             logsIndex.Name,
+		NumRetentionDays: logsIndex.NumRetentionDays,
+		DailyLimit:       logsIndex.DailyLimit,
+		IsRateLimited:    logsIndex.IsRateLimited,
+		Filter:           updateLogsIndex.Filter,
+		ExclusionFilters: updateLogsIndex.ExclusionFilters,
+	}, updatedLogsIndex)
+
+}
+
+func TestUpdateIndexList(t *testing.T) {
+	indexList, err := client.GetLogsIndexList()
+	assert.Nil(t, err)
+	size := len(indexList.IndexNames)
+	updateList := make([]string, size)
+	for i, name := range indexList.IndexNames {
+		updateList[size-1-i] = name
+	}
+	updateIndexList := &datadog.LogsIndexList{IndexNames: updateList}
+	updatedIndexList, err := client.UpdateLogsIndexList(updateIndexList)
+	defer assertRevertOrder(t, indexList)
+	assert.Nil(t, err)
+	assert.Equal(t, updateIndexList, updatedIndexList)
+}
+
+func assertRevertOrder(t *testing.T, indexList *datadog.LogsIndexList) {
+	revertedList, err := client.UpdateLogsIndexList(indexList)
+	assert.Nil(t, err)
+	assert.Equal(t, indexList, revertedList)
+}
+
+func assertRevertChange(t *testing.T, logsIndex *datadog.LogsIndex) {
+	revertLogsIndex, err := client.UpdateLogsIndex(*logsIndex.Name, &datadog.LogsIndex{
+		Filter:           logsIndex.Filter,
+		ExclusionFilters: logsIndex.ExclusionFilters,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, revertLogsIndex, logsIndex)
+}

--- a/logs_index_lists.go
+++ b/logs_index_lists.go
@@ -1,0 +1,26 @@
+package datadog
+
+const logsIndexListPath = "/v1/logs/config/index-order"
+
+// LogsIndexList represents the index list object from config API.
+type LogsIndexList struct {
+	IndexNames []string `json:"index_names"`
+}
+
+// GetLogsIndexList gets the full list of available indexes by their names.
+func (client *Client) GetLogsIndexList() (*LogsIndexList, error) {
+	var indexList LogsIndexList
+	if err := client.doJsonRequest("GET", logsIndexListPath, nil, &indexList); err != nil {
+		return nil, err
+	}
+	return &indexList, nil
+}
+
+// UpdateLogsIndexList updates the order of indexes.
+func (client *Client) UpdateLogsIndexList(indexList *LogsIndexList) (*LogsIndexList, error) {
+	var updatedIndexList = &LogsIndexList{}
+	if err := client.doJsonRequest("PUT", logsIndexListPath, indexList, updatedIndexList); err != nil {
+		return nil, err
+	}
+	return updatedIndexList, nil
+}

--- a/logs_index_lists_test.go
+++ b/logs_index_lists_test.go
@@ -1,0 +1,31 @@
+package datadog
+
+import (
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLogsIndexListGet(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response, err := ioutil.ReadFile("./tests/fixtures/logs/indexlist_response.json")
+		assert.Nil(t, err)
+		w.Write(response)
+	}))
+
+	defer ts.Close()
+
+	client := Client{
+		baseUrl:    ts.URL,
+		HttpClient: http.DefaultClient,
+	}
+
+	indexList, err := client.GetLogsIndexList()
+
+	assert.Nil(t, err)
+
+	assert.Equal(t, []string{"main", "minor"}, indexList.IndexNames)
+
+}

--- a/logs_indexes.go
+++ b/logs_indexes.go
@@ -1,0 +1,48 @@
+package datadog
+
+import (
+	"fmt"
+)
+
+const logsIndexPath = "/v1/logs/config/indexes"
+
+// LogsIndex represents the Logs index object from config API.
+type LogsIndex struct {
+	Name             *string              `json:"name"`
+	NumRetentionDays *int64               `json:"num_retention_days,omitempty"`
+	DailyLimit       *int64               `json:"daily_limit,omitempty"`
+	IsRateLimited    *bool                `json:"is_rate_limited,omitempty"`
+	Filter           *FilterConfiguration `json:"filter"`
+	ExclusionFilters []ExclusionFilter    `json:"exclusion_filters"`
+}
+
+// ExclusionFilter represents the index exclusion filter object from config API.
+type ExclusionFilter struct {
+	Name      *string `json:"name"`
+	IsEnabled *bool   `json:"is_enabled,omitempty"`
+	Filter    *Filter `json:"filter"`
+}
+
+// Filter represents the index filter object from config API.
+type Filter struct {
+	Query      *string  `json:"query,omitempty"`
+	SampleRate *float64 `json:"sample_rate,omitempty"`
+}
+
+// GetLogsIndex gets the specific logs index by specific name.
+func (client *Client) GetLogsIndex(name string) (*LogsIndex, error) {
+	var index LogsIndex
+	if err := client.doJsonRequest("GET", fmt.Sprintf("%s/%s", logsIndexPath, name), nil, &index); err != nil {
+		return nil, err
+	}
+	return &index, nil
+}
+
+// UpdateLogsIndex updates the specific index by it's name.
+func (client *Client) UpdateLogsIndex(name string, index *LogsIndex) (*LogsIndex, error) {
+	var updatedIndex = &LogsIndex{}
+	if err := client.doJsonRequest("PUT", fmt.Sprintf("%s/%s", logsIndexPath, name), index, updatedIndex); err != nil {
+		return nil, err
+	}
+	return updatedIndex, nil
+}

--- a/logs_indexes_test.go
+++ b/logs_indexes_test.go
@@ -1,0 +1,62 @@
+package datadog
+
+import (
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLogsIndexGet(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response, err := ioutil.ReadFile("./tests/fixtures/logs/index_response.json")
+		if err != nil {
+			t.Fatal(err)
+		}
+		w.Write(response)
+	}))
+
+	defer ts.Close()
+
+	client := Client{
+		baseUrl:    ts.URL,
+		HttpClient: http.DefaultClient,
+	}
+
+	logsIndex, err := client.GetLogsIndex("main")
+	assert.Nil(t, err)
+	assert.Equal(t, expectedIndex, logsIndex)
+}
+
+var expectedIndex = &LogsIndex{
+	Name:             String("main"),
+	NumRetentionDays: Int64(90),
+	DailyLimit:       Int64(151000000),
+	IsRateLimited:    Bool(false),
+	Filter:           &FilterConfiguration{Query: String("*")},
+	ExclusionFilters: []ExclusionFilter{
+		{
+			Name:      String("Filter 1"),
+			IsEnabled: Bool(true),
+			Filter: &Filter{
+				Query:      String("source:agent status:info"),
+				SampleRate: Float64(1.0),
+			},
+		}, {
+			Name:      String("Filter 2"),
+			IsEnabled: Bool(true),
+			Filter: &Filter{
+				Query:      String("source:agent"),
+				SampleRate: Float64(0.8),
+			},
+		}, {
+			Name:      String("Filter 3"),
+			IsEnabled: Bool(true),
+			Filter: &Filter{
+				Query:      String("source:debug"),
+				SampleRate: Float64(0.5),
+			},
+		},
+	},
+}

--- a/tests/fixtures/logs/index_response.json
+++ b/tests/fixtures/logs/index_response.json
@@ -1,0 +1,35 @@
+{
+  "name": "main",
+  "filter": {
+    "query": "*"
+  },
+  "num_retention_days": 90,
+  "daily_limit": 151000000,
+  "is_rate_limited": false,
+  "exclusion_filters": [
+    {
+      "name": "Filter 1",
+      "is_enabled": true,
+      "filter": {
+        "query": "source:agent status:info",
+        "sample_rate": 1.0
+      }
+    },
+    {
+      "name": "Filter 2",
+      "is_enabled": true,
+      "filter": {
+        "query": "source:agent",
+        "sample_rate": 0.8
+      }
+    },
+    {
+      "name": "Filter 3",
+      "is_enabled": true,
+      "filter": {
+        "query": "source:debug",
+        "sample_rate": 0.5
+      }
+    }
+  ]
+}

--- a/tests/fixtures/logs/indexlist_response.json
+++ b/tests/fixtures/logs/indexlist_response.json
@@ -1,0 +1,6 @@
+{
+  "index_names": [
+    "main",
+    "minor"
+  ]
+}


### PR DESCRIPTION
Add functions to support GET and UPDATE requests for logs index API. The DELETE | CREATE requests are not supported from logs index API.