### PR TITLE
Add GetMonitorsByMonitorTags function

### DIFF
--- a/monitors.go
+++ b/monitors.go
@@ -191,6 +191,11 @@ func (client *Client) GetMonitorsByTags(tags []string) ([]Monitor, error) {
 	return client.GetMonitorsWithOptions(MonitorQueryOpts{Tags: tags})
 }
 
+// GetMonitorsByMonitorTags retrieves monitors by a slice of monitor tags
+func (client *Client) GetMonitorsByMonitorTags(tags []string) ([]Monitor, error) {
+	return client.GetMonitorsWithOptions(MonitorQueryOpts{MonitorTags: tags})
+}
+
 // DeleteMonitor removes a monitor from the system
 func (client *Client) DeleteMonitor(id int) error {
 	return client.doJsonRequest("DELETE", fmt.Sprintf("/v1/monitor/%d", id),


### PR DESCRIPTION
Previous behaviour was being able to fetch monitors using the custom tags assigned to a monitor which the API calls "monitor_tags".

I think quite rightly this was defined explicitly in the MonitorQueryOpts type, but we lost the function to be able to fetch monitors based upon those tags when this was added in[2].

Add a function back to enable me to fetch these monitors using those custom tags again.

[1] https://docs.datadoghq.com/api/?lang=bash#get-all-monitor-details
[2] e0e11313d2bfb4f35f7a2b6f9019a098f9d822b5