### PR TITLE
/validate endpoint does not check app key validity

### DIFF
--- a/client.go
+++ b/client.go
@@ -68,7 +68,7 @@ func (c *Client) GetBaseUrl() string {
 	return c.baseUrl
 }
 
-// Validate checks if the API and application keys are valid.
+// Validate checks if the API key (not the APP key) is valid.
 func (client *Client) Validate() (bool, error) {
 	var out valid
 	var resp *http.Response


### PR DESCRIPTION
https://docs.datadoghq.com/api/?lang=bash#authentication

This only checks the API key.
You can supply a bad APP key and it will still be valid if only the API key is valid.