### PR TITLE
Update GCP integration

### DIFF
--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -10275,6 +10275,37 @@ func (i *IntegrationAWSServicesLogCollection) SetAccountID(v string) {
 	i.AccountID = &v
 }
 
+// GetAutoMute returns the AutoMute field if non-nil, zero value otherwise.
+func (i *IntegrationGCP) GetAutoMute() string {
+	if i == nil || i.AutoMute == nil {
+		return ""
+	}
+	return *i.AutoMute
+}
+
+// GetAutoMuteOk returns a tuple with the AutoMute field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (i *IntegrationGCP) GetAutoMuteOk() (string, bool) {
+	if i == nil || i.AutoMute == nil {
+		return "", false
+	}
+	return *i.AutoMute, true
+}
+
+// HasAutoMute returns a boolean if a field has been set.
+func (i *IntegrationGCP) HasAutoMute() bool {
+	if i != nil && i.AutoMute != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAutoMute allocates a new i.AutoMute and returns the pointer to it.
+func (i *IntegrationGCP) SetAutoMute(v string) {
+	i.AutoMute = &v
+}
+
 // GetClientEmail returns the ClientEmail field if non-nil, zero value otherwise.
 func (i *IntegrationGCP) GetClientEmail() string {
 	if i == nil || i.ClientEmail == nil {
@@ -10428,6 +10459,37 @@ func (i *IntegrationGCPCreateRequest) HasAuthURI() bool {
 // SetAuthURI allocates a new i.AuthURI and returns the pointer to it.
 func (i *IntegrationGCPCreateRequest) SetAuthURI(v string) {
 	i.AuthURI = &v
+}
+
+// GetAutoMute returns the AutoMute field if non-nil, zero value otherwise.
+func (i *IntegrationGCPCreateRequest) GetAutoMute() bool {
+	if i == nil || i.AutoMute == nil {
+		return false
+	}
+	return *i.AutoMute
+}
+
+// GetAutoMuteOk returns a tuple with the AutoMute field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (i *IntegrationGCPCreateRequest) GetAutoMuteOk() (bool, bool) {
+	if i == nil || i.AutoMute == nil {
+		return false, false
+	}
+	return *i.AutoMute, true
+}
+
+// HasAutoMute returns a boolean if a field has been set.
+func (i *IntegrationGCPCreateRequest) HasAutoMute() bool {
+	if i != nil && i.AutoMute != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAutoMute allocates a new i.AutoMute and returns the pointer to it.
+func (i *IntegrationGCPCreateRequest) SetAutoMute(v bool) {
+	i.AutoMute = &v
 }
 
 // GetClientEmail returns the ClientEmail field if non-nil, zero value otherwise.
@@ -10771,6 +10833,99 @@ func (i *IntegrationGCPDeleteRequest) SetProjectID(v string) {
 	i.ProjectID = &v
 }
 
+// GetAuthProviderX509CertURL returns the AuthProviderX509CertURL field if non-nil, zero value otherwise.
+func (i *IntegrationGCPUpdateRequest) GetAuthProviderX509CertURL() string {
+	if i == nil || i.AuthProviderX509CertURL == nil {
+		return ""
+	}
+	return *i.AuthProviderX509CertURL
+}
+
+// GetAuthProviderX509CertURLOk returns a tuple with the AuthProviderX509CertURL field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (i *IntegrationGCPUpdateRequest) GetAuthProviderX509CertURLOk() (string, bool) {
+	if i == nil || i.AuthProviderX509CertURL == nil {
+		return "", false
+	}
+	return *i.AuthProviderX509CertURL, true
+}
+
+// HasAuthProviderX509CertURL returns a boolean if a field has been set.
+func (i *IntegrationGCPUpdateRequest) HasAuthProviderX509CertURL() bool {
+	if i != nil && i.AuthProviderX509CertURL != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAuthProviderX509CertURL allocates a new i.AuthProviderX509CertURL and returns the pointer to it.
+func (i *IntegrationGCPUpdateRequest) SetAuthProviderX509CertURL(v string) {
+	i.AuthProviderX509CertURL = &v
+}
+
+// GetAuthURI returns the AuthURI field if non-nil, zero value otherwise.
+func (i *IntegrationGCPUpdateRequest) GetAuthURI() string {
+	if i == nil || i.AuthURI == nil {
+		return ""
+	}
+	return *i.AuthURI
+}
+
+// GetAuthURIOk returns a tuple with the AuthURI field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (i *IntegrationGCPUpdateRequest) GetAuthURIOk() (string, bool) {
+	if i == nil || i.AuthURI == nil {
+		return "", false
+	}
+	return *i.AuthURI, true
+}
+
+// HasAuthURI returns a boolean if a field has been set.
+func (i *IntegrationGCPUpdateRequest) HasAuthURI() bool {
+	if i != nil && i.AuthURI != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAuthURI allocates a new i.AuthURI and returns the pointer to it.
+func (i *IntegrationGCPUpdateRequest) SetAuthURI(v string) {
+	i.AuthURI = &v
+}
+
+// GetAutoMute returns the AutoMute field if non-nil, zero value otherwise.
+func (i *IntegrationGCPUpdateRequest) GetAutoMute() bool {
+	if i == nil || i.AutoMute == nil {
+		return false
+	}
+	return *i.AutoMute
+}
+
+// GetAutoMuteOk returns a tuple with the AutoMute field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (i *IntegrationGCPUpdateRequest) GetAutoMuteOk() (bool, bool) {
+	if i == nil || i.AutoMute == nil {
+		return false, false
+	}
+	return *i.AutoMute, true
+}
+
+// HasAutoMute returns a boolean if a field has been set.
+func (i *IntegrationGCPUpdateRequest) HasAutoMute() bool {
+	if i != nil && i.AutoMute != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetAutoMute allocates a new i.AutoMute and returns the pointer to it.
+func (i *IntegrationGCPUpdateRequest) SetAutoMute(v bool) {
+	i.AutoMute = &v
+}
+
 // GetClientEmail returns the ClientEmail field if non-nil, zero value otherwise.
 func (i *IntegrationGCPUpdateRequest) GetClientEmail() string {
 	if i == nil || i.ClientEmail == nil {
@@ -10800,6 +10955,68 @@ func (i *IntegrationGCPUpdateRequest) HasClientEmail() bool {
 // SetClientEmail allocates a new i.ClientEmail and returns the pointer to it.
 func (i *IntegrationGCPUpdateRequest) SetClientEmail(v string) {
 	i.ClientEmail = &v
+}
+
+// GetClientID returns the ClientID field if non-nil, zero value otherwise.
+func (i *IntegrationGCPUpdateRequest) GetClientID() string {
+	if i == nil || i.ClientID == nil {
+		return ""
+	}
+	return *i.ClientID
+}
+
+// GetClientIDOk returns a tuple with the ClientID field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (i *IntegrationGCPUpdateRequest) GetClientIDOk() (string, bool) {
+	if i == nil || i.ClientID == nil {
+		return "", false
+	}
+	return *i.ClientID, true
+}
+
+// HasClientID returns a boolean if a field has been set.
+func (i *IntegrationGCPUpdateRequest) HasClientID() bool {
+	if i != nil && i.ClientID != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetClientID allocates a new i.ClientID and returns the pointer to it.
+func (i *IntegrationGCPUpdateRequest) SetClientID(v string) {
+	i.ClientID = &v
+}
+
+// GetClientX509CertURL returns the ClientX509CertURL field if non-nil, zero value otherwise.
+func (i *IntegrationGCPUpdateRequest) GetClientX509CertURL() string {
+	if i == nil || i.ClientX509CertURL == nil {
+		return ""
+	}
+	return *i.ClientX509CertURL
+}
+
+// GetClientX509CertURLOk returns a tuple with the ClientX509CertURL field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (i *IntegrationGCPUpdateRequest) GetClientX509CertURLOk() (string, bool) {
+	if i == nil || i.ClientX509CertURL == nil {
+		return "", false
+	}
+	return *i.ClientX509CertURL, true
+}
+
+// HasClientX509CertURL returns a boolean if a field has been set.
+func (i *IntegrationGCPUpdateRequest) HasClientX509CertURL() bool {
+	if i != nil && i.ClientX509CertURL != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetClientX509CertURL allocates a new i.ClientX509CertURL and returns the pointer to it.
+func (i *IntegrationGCPUpdateRequest) SetClientX509CertURL(v string) {
+	i.ClientX509CertURL = &v
 }
 
 // GetHostFilters returns the HostFilters field if non-nil, zero value otherwise.
@@ -10833,6 +11050,68 @@ func (i *IntegrationGCPUpdateRequest) SetHostFilters(v string) {
 	i.HostFilters = &v
 }
 
+// GetPrivateKey returns the PrivateKey field if non-nil, zero value otherwise.
+func (i *IntegrationGCPUpdateRequest) GetPrivateKey() string {
+	if i == nil || i.PrivateKey == nil {
+		return ""
+	}
+	return *i.PrivateKey
+}
+
+// GetPrivateKeyOk returns a tuple with the PrivateKey field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (i *IntegrationGCPUpdateRequest) GetPrivateKeyOk() (string, bool) {
+	if i == nil || i.PrivateKey == nil {
+		return "", false
+	}
+	return *i.PrivateKey, true
+}
+
+// HasPrivateKey returns a boolean if a field has been set.
+func (i *IntegrationGCPUpdateRequest) HasPrivateKey() bool {
+	if i != nil && i.PrivateKey != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetPrivateKey allocates a new i.PrivateKey and returns the pointer to it.
+func (i *IntegrationGCPUpdateRequest) SetPrivateKey(v string) {
+	i.PrivateKey = &v
+}
+
+// GetPrivateKeyID returns the PrivateKeyID field if non-nil, zero value otherwise.
+func (i *IntegrationGCPUpdateRequest) GetPrivateKeyID() string {
+	if i == nil || i.PrivateKeyID == nil {
+		return ""
+	}
+	return *i.PrivateKeyID
+}
+
+// GetPrivateKeyIDOk returns a tuple with the PrivateKeyID field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (i *IntegrationGCPUpdateRequest) GetPrivateKeyIDOk() (string, bool) {
+	if i == nil || i.PrivateKeyID == nil {
+		return "", false
+	}
+	return *i.PrivateKeyID, true
+}
+
+// HasPrivateKeyID returns a boolean if a field has been set.
+func (i *IntegrationGCPUpdateRequest) HasPrivateKeyID() bool {
+	if i != nil && i.PrivateKeyID != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetPrivateKeyID allocates a new i.PrivateKeyID and returns the pointer to it.
+func (i *IntegrationGCPUpdateRequest) SetPrivateKeyID(v string) {
+	i.PrivateKeyID = &v
+}
+
 // GetProjectID returns the ProjectID field if non-nil, zero value otherwise.
 func (i *IntegrationGCPUpdateRequest) GetProjectID() string {
 	if i == nil || i.ProjectID == nil {
@@ -10862,6 +11141,68 @@ func (i *IntegrationGCPUpdateRequest) HasProjectID() bool {
 // SetProjectID allocates a new i.ProjectID and returns the pointer to it.
 func (i *IntegrationGCPUpdateRequest) SetProjectID(v string) {
 	i.ProjectID = &v
+}
+
+// GetTokenURI returns the TokenURI field if non-nil, zero value otherwise.
+func (i *IntegrationGCPUpdateRequest) GetTokenURI() string {
+	if i == nil || i.TokenURI == nil {
+		return ""
+	}
+	return *i.TokenURI
+}
+
+// GetTokenURIOk returns a tuple with the TokenURI field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (i *IntegrationGCPUpdateRequest) GetTokenURIOk() (string, bool) {
+	if i == nil || i.TokenURI == nil {
+		return "", false
+	}
+	return *i.TokenURI, true
+}
+
+// HasTokenURI returns a boolean if a field has been set.
+func (i *IntegrationGCPUpdateRequest) HasTokenURI() bool {
+	if i != nil && i.TokenURI != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetTokenURI allocates a new i.TokenURI and returns the pointer to it.
+func (i *IntegrationGCPUpdateRequest) SetTokenURI(v string) {
+	i.TokenURI = &v
+}
+
+// GetType returns the Type field if non-nil, zero value otherwise.
+func (i *IntegrationGCPUpdateRequest) GetType() string {
+	if i == nil || i.Type == nil {
+		return ""
+	}
+	return *i.Type
+}
+
+// GetTypeOk returns a tuple with the Type field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (i *IntegrationGCPUpdateRequest) GetTypeOk() (string, bool) {
+	if i == nil || i.Type == nil {
+		return "", false
+	}
+	return *i.Type, true
+}
+
+// HasType returns a boolean if a field has been set.
+func (i *IntegrationGCPUpdateRequest) HasType() bool {
+	if i != nil && i.Type != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetType allocates a new i.Type and returns the pointer to it.
+func (i *IntegrationGCPUpdateRequest) SetType(v string) {
+	i.Type = &v
 }
 
 // GetAPIToken returns the APIToken field if non-nil, zero value otherwise.

--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -10276,18 +10276,18 @@ func (i *IntegrationAWSServicesLogCollection) SetAccountID(v string) {
 }
 
 // GetAutoMute returns the AutoMute field if non-nil, zero value otherwise.
-func (i *IntegrationGCP) GetAutoMute() string {
+func (i *IntegrationGCP) GetAutoMute() bool {
 	if i == nil || i.AutoMute == nil {
-		return ""
+		return false
 	}
 	return *i.AutoMute
 }
 
 // GetAutoMuteOk returns a tuple with the AutoMute field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (i *IntegrationGCP) GetAutoMuteOk() (string, bool) {
+func (i *IntegrationGCP) GetAutoMuteOk() (bool, bool) {
 	if i == nil || i.AutoMute == nil {
-		return "", false
+		return false, false
 	}
 	return *i.AutoMute, true
 }
@@ -10302,7 +10302,7 @@ func (i *IntegrationGCP) HasAutoMute() bool {
 }
 
 // SetAutoMute allocates a new i.AutoMute and returns the pointer to it.
-func (i *IntegrationGCP) SetAutoMute(v string) {
+func (i *IntegrationGCP) SetAutoMute(v bool) {
 	i.AutoMute = &v
 }
 

--- a/integration/integrations_test.go
+++ b/integration/integrations_test.go
@@ -399,6 +399,7 @@ func TestIntegrationGCPCreateAndDelete(t *testing.T) {
 	assert.Equal(t, expected.ProjectID, actual[0].ProjectID)
 	assert.Equal(t, expected.ClientEmail, actual[0].ClientEmail)
 	assert.Equal(t, expected.HostFilters, actual[0].HostFilters)
+	assert.Equal(t, expected.AutoMute, actual[0].AutoMute)
 }
 
 func TestIntegrationGCPUpdate(t *testing.T) {
@@ -406,11 +407,21 @@ func TestIntegrationGCPUpdate(t *testing.T) {
 	defer cleanUpIntegrationGCP(t)
 
 	newHostFilters := datadog.String("name0:value0,name1:value1")
+	newAutoMute := datadog.Bool(false)
 
 	if err := client.UpdateIntegrationGCP(&datadog.IntegrationGCPUpdateRequest{
-		ProjectID:   req.ProjectID,
-		ClientEmail: req.ClientEmail,
-		HostFilters: newHostFilters,
+		Type:                    req.Type,
+		ProjectID:               req.ProjectID,
+		PrivateKeyID:            req.PrivateKeyID,
+		PrivateKey:              req.PrivateKey,
+		ClientEmail:             req.ClientEmail,
+		ClientID:                req.ClientID,
+		AuthURI:                 req.AuthURI,
+		TokenURI:                req.TokenURI,
+		AuthProviderX509CertURL: req.AuthProviderX509CertURL,
+		ClientX509CertURL:       req.ClientX509CertURL,
+		HostFilters:             newHostFilters,
+		AutoMute:                newAutoMute,
 	}); err != nil {
 		t.Fatalf("Updating a GCP integration failed when it shouldn't: %s", err)
 	}
@@ -423,6 +434,7 @@ func TestIntegrationGCPUpdate(t *testing.T) {
 	assert.Equal(t, req.ProjectID, actual[0].ProjectID)
 	assert.Equal(t, req.ClientEmail, actual[0].ClientEmail)
 	assert.Equal(t, newHostFilters, actual[0].HostFilters)
+	assert.Equal(t, newAutoMute, actual[0].AutoMute)
 }
 
 func getTestIntegrationGCPCreateRequest() *datadog.IntegrationGCPCreateRequest {
@@ -438,6 +450,7 @@ func getTestIntegrationGCPCreateRequest() *datadog.IntegrationGCPCreateRequest {
 		AuthProviderX509CertURL: datadog.String("https://www.googleapis.com/oauth2/v1/certs"),
 		ClientX509CertURL:       datadog.String("https://www.googleapis.com/robot/v1/metadata/x509/go-datadog-api@test-project-id.iam.gserviceaccount.com"),
 		HostFilters:             datadog.String("foo:bar,buzz:lightyear"),
+		AutoMute:                datadog.Bool(true),
 	}
 }
 

--- a/integrations.go
+++ b/integrations.go
@@ -278,7 +278,7 @@ type IntegrationGCP struct {
 	ProjectID   *string `json:"project_id"`
 	ClientEmail *string `json:"client_email"`
 	HostFilters *string `json:"host_filters"`
-	AutoMute    *string `json:"automute,omitempty"`
+	AutoMute    *bool   `json:"automute,omitempty"`
 }
 
 // IntegrationGCPCreateRequest defines the request payload for creating Datadog-Google CloudPlatform integration.

--- a/integrations.go
+++ b/integrations.go
@@ -328,6 +328,11 @@ func (client *Client) UpdateIntegrationGCP(cir *IntegrationGCPUpdateRequest) err
 	return client.doJsonRequest("POST", "/v1/integration/gcp/host_filters", cir, nil)
 }
 
+// UpdateIntegrationGCPProject updates a Google Cloud Platform Integration project.
+func (client *Client) UpdateIntegrationGCPProject(cir *IntegrationGCPCreateRequest) error {
+	return client.doJsonRequest("PUT", "/v1/integration/gcp", cir, nil)
+}
+
 // DeleteIntegrationGCP deletes a Google Cloud Platform Integration.
 func (client *Client) DeleteIntegrationGCP(cir *IntegrationGCPDeleteRequest) error {
 	return client.doJsonRequest("DELETE", "/v1/integration/gcp", cir, nil)

--- a/integrations.go
+++ b/integrations.go
@@ -293,6 +293,7 @@ type IntegrationGCPCreateRequest struct {
 	AuthProviderX509CertURL *string `json:"auth_provider_x509_cert_url"` // Should be https://www.googleapis.com/oauth2/v1/certs
 	ClientX509CertURL       *string `json:"client_x509_cert_url"`        // https://www.googleapis.com/robot/v1/metadata/x509/<CLIENT_EMAIL>
 	HostFilters             *string `json:"host_filters,omitempty"`
+	AutoMute                *bool   `json:"automute,omitempty"`
 }
 
 // IntegrationGCPUpdateRequest defines the request payload for updating Datadog-Google CloudPlatform integration.

--- a/integrations.go
+++ b/integrations.go
@@ -278,6 +278,7 @@ type IntegrationGCP struct {
 	ProjectID   *string `json:"project_id"`
 	ClientEmail *string `json:"client_email"`
 	HostFilters *string `json:"host_filters"`
+	AutoMute    *string `json:"automute,omitempty"`
 }
 
 // IntegrationGCPCreateRequest defines the request payload for creating Datadog-Google CloudPlatform integration.
@@ -298,9 +299,18 @@ type IntegrationGCPCreateRequest struct {
 
 // IntegrationGCPUpdateRequest defines the request payload for updating Datadog-Google CloudPlatform integration.
 type IntegrationGCPUpdateRequest struct {
-	ProjectID   *string `json:"project_id"`
-	ClientEmail *string `json:"client_email"`
-	HostFilters *string `json:"host_filters,omitempty"`
+	Type                    *string `json:"type,omitempty"` // Should be service_account
+	ProjectID               *string `json:"project_id"`
+	PrivateKeyID            *string `json:"private_key_id,omitempty"`
+	PrivateKey              *string `json:"private_key,omitempty"`
+	ClientEmail             *string `json:"client_email"`
+	ClientID                *string `json:"client_id,omitempty"`
+	AuthURI                 *string `json:"auth_uri,omitempty"`                    // Should be https://accounts.google.com/o/oauth2/auth
+	TokenURI                *string `json:"token_uri,omitempty"`                   // Should be https://accounts.google.com/o/oauth2/token
+	AuthProviderX509CertURL *string `json:"auth_provider_x509_cert_url,omitempty"` // Should be https://www.googleapis.com/oauth2/v1/certs
+	ClientX509CertURL       *string `json:"client_x509_cert_url,omitempty"`        // https://www.googleapis.com/robot/v1/metadata/x509/<CLIENT_EMAIL>
+	HostFilters             *string `json:"host_filters,omitempty"`
+	AutoMute                *bool   `json:"automute,omitempty"`
 }
 
 // IntegrationGCPDeleteRequest defines the request payload for deleting Datadog-Google CloudPlatform integration.
@@ -323,13 +333,8 @@ func (client *Client) CreateIntegrationGCP(cir *IntegrationGCPCreateRequest) err
 	return client.doJsonRequest("POST", "/v1/integration/gcp", cir, nil)
 }
 
-// UpdateIntegrationGCP updates a Google Cloud Platform Integration.
+// UpdateIntegrationGCP updates a Google Cloud Platform Integration project.
 func (client *Client) UpdateIntegrationGCP(cir *IntegrationGCPUpdateRequest) error {
-	return client.doJsonRequest("POST", "/v1/integration/gcp/host_filters", cir, nil)
-}
-
-// UpdateIntegrationGCPProject updates a Google Cloud Platform Integration project.
-func (client *Client) UpdateIntegrationGCPProject(cir *IntegrationGCPCreateRequest) error {
 	return client.doJsonRequest("PUT", "/v1/integration/gcp", cir, nil)
 }
 


### PR DESCRIPTION
What does this PR do?
----------------------

- Adds the field `AutoMute` to the `IntegrationGCPCreateRequest` object.
- Updates the IntegrationGCP object
- Refactors the UpdateIntegrationGCP function as it was not working anymore (the endpoints does not seem to work)
  - for backward compatibility, the IntegrationGCPUpdateRequest object was just updated instead of using the already existing IntegrationGCPCreateRequest object, which is identical
- Updates the `integration/integration_test.go` tests functions for the GCP integration, adding checks for the `AutoMute` field