### PR TITLE
Support `interval` field on metrics POST

### DIFF
--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -12569,6 +12569,37 @@ func (m *Metric) SetHost(v string) {
 	m.Host = &v
 }
 
+// GetInterval returns the Interval field if non-nil, zero value otherwise.
+func (m *Metric) GetInterval() int {
+	if m == nil || m.Interval == nil {
+		return 0
+	}
+	return *m.Interval
+}
+
+// GetIntervalOk returns a tuple with the Interval field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (m *Metric) GetIntervalOk() (int, bool) {
+	if m == nil || m.Interval == nil {
+		return 0, false
+	}
+	return *m.Interval, true
+}
+
+// HasInterval returns a boolean if a field has been set.
+func (m *Metric) HasInterval() bool {
+	if m != nil && m.Interval != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetInterval allocates a new m.Interval and returns the pointer to it.
+func (m *Metric) SetInterval(v int) {
+	m.Interval = &v
+}
+
 // GetMetric returns the Metric field if non-nil, zero value otherwise.
 func (m *Metric) GetMetric() string {
 	if m == nil || m.Metric == nil {

--- a/series.go
+++ b/series.go
@@ -26,7 +26,7 @@ type Metric struct {
 	Host     *string     `json:"host,omitempty"`
 	Tags     []string    `json:"tags,omitempty"`
 	Unit     *string     `json:"unit,omitempty"`
-	Interval int         `json:"interval,omitempty"`
+	Interval *int        `json:"interval,omitempty"`
 }
 
 // Unit represents a unit definition that we might receive when query for timeseries data.

--- a/series.go
+++ b/series.go
@@ -20,12 +20,13 @@ type DataPoint [2]*float64
 // Metric represents a collection of data points that we might send or receive
 // on one single metric line.
 type Metric struct {
-	Metric *string     `json:"metric,omitempty"`
-	Points []DataPoint `json:"points,omitempty"`
-	Type   *string     `json:"type,omitempty"`
-	Host   *string     `json:"host,omitempty"`
-	Tags   []string    `json:"tags,omitempty"`
-	Unit   *string     `json:"unit,omitempty"`
+	Metric   *string     `json:"metric,omitempty"`
+	Points   []DataPoint `json:"points,omitempty"`
+	Type     *string     `json:"type,omitempty"`
+	Host     *string     `json:"host,omitempty"`
+	Tags     []string    `json:"tags,omitempty"`
+	Unit     *string     `json:"unit,omitempty"`
+	Interval int         `json:"interval,omitempty"`
 }
 
 // Unit represents a unit definition that we might receive when query for timeseries data.

--- a/series_test.go
+++ b/series_test.go
@@ -1,0 +1,78 @@
+package datadog
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func removeWhitespace(s string) string {
+	s = strings.Replace(s, " ", "", -1)
+	s = strings.Replace(s, "\n", "", -1)
+	return s
+}
+
+// TestPostMetrics tests submitting series sends correct
+// payloads to the Datadog API for the /v1/series endpoint
+func TestPostMetrics(t *testing.T) {
+	reqs := make(chan string, 1)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(r.Body)
+		reqs <- buf.String()
+		w.WriteHeader(200)
+		w.Write([]byte("{\"status\": \"ok\"}"))
+		return
+	}))
+	defer ts.Close()
+
+	client := Client{
+		baseUrl:    ts.URL,
+		HttpClient: http.DefaultClient,
+	}
+
+	tcs := []string{
+		"./tests/fixtures/series/post_series_mixed.json",
+		"./tests/fixtures/series/post_series_valid.json",
+	}
+
+	for _, tc := range tcs {
+		b, err := ioutil.ReadFile(tc)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var post reqPostSeries
+		json.Unmarshal(b, &post)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = client.PostMetrics(post.Series)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, nil, err)
+
+		payload := <-reqs
+		assert.Equal(t, removeWhitespace(string(b)), payload)
+	}
+
+	// Empty slice metrics test case
+
+	err := client.PostMetrics([]Metric{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	payload := <-reqs
+	assert.Equal(t, "{}", payload)
+}

--- a/tests/fixtures/series/post_series_mixed.json
+++ b/tests/fixtures/series/post_series_mixed.json
@@ -1,0 +1,19 @@
+{"series" :
+    [
+        {"metric":"test.metric",
+         "points":[[1575591864, 20]],
+         "type":"rate",
+         "host":"test.example.com",
+         "tags":["environment:test"],
+         "interval": 20},
+        {"metric":"test.metric.duration",
+         "points":[[1575591810.01, 73.45]],
+         "type":"gauge"},
+        {"metric":"test.metric.hits",
+         "points":[
+             [1575591810.5, 54],
+             [1575591899.6, 73],
+             [1575591810.9, 73]
+        ]}
+   ]
+}

--- a/tests/fixtures/series/post_series_valid.json
+++ b/tests/fixtures/series/post_series_valid.json
@@ -1,0 +1,9 @@
+{"series" :
+    [{"metric":"test.metric",
+     "points":[[1575591864, 20]],
+     "type":"rate",
+     "host":"test.example.com",
+     "tags":["environment:test"],
+     "interval": 20}
+   ]
+}


### PR DESCRIPTION
Adds support for submitting the `interval` for metrics, which is [supported by the API](https://docs.datadoghq.com/api/?lang=bash#post-timeseries-points).