### PR TITLE
Add Retry to Synthetics

### DIFF
--- a/api_keys.go
+++ b/api_keys.go
@@ -19,7 +19,7 @@ var createdTimeLayout = "2006-01-02 15:04:05"
 // APIKey represents and API key
 type APIKey struct {
 	CreatedBy *string    `json:"created_by,omitempty"`
-	Name      *string    `json:"name,omitemtpy"`
+	Name      *string    `json:"name,omitempty"`
 	Key       *string    `json:"key,omitempty"`
 	Created   *time.Time `json:"created,omitempty"`
 }

--- a/app_keys.go
+++ b/app_keys.go
@@ -15,7 +15,7 @@ import (
 // APPKey represents an APP key
 type APPKey struct {
 	Owner *string `json:"owner,omitempty"`
-	Name  *string `json:"name,omitemtpy"`
+	Name  *string `json:"name,omitempty"`
 	Hash  *string `json:"hash,omitempty"`
 }
 

--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -16351,6 +16351,68 @@ func (r *reqUpdateUser) SetVerified(v bool) {
 	r.Verified = &v
 }
 
+// GetCount returns the Count field if non-nil, zero value otherwise.
+func (r *Retry) GetCount() int {
+	if r == nil || r.Count == nil {
+		return 0
+	}
+	return *r.Count
+}
+
+// GetCountOk returns a tuple with the Count field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (r *Retry) GetCountOk() (int, bool) {
+	if r == nil || r.Count == nil {
+		return 0, false
+	}
+	return *r.Count, true
+}
+
+// HasCount returns a boolean if a field has been set.
+func (r *Retry) HasCount() bool {
+	if r != nil && r.Count != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCount allocates a new r.Count and returns the pointer to it.
+func (r *Retry) SetCount(v int) {
+	r.Count = &v
+}
+
+// GetInterval returns the Interval field if non-nil, zero value otherwise.
+func (r *Retry) GetInterval() int {
+	if r == nil || r.Interval == nil {
+		return 0
+	}
+	return *r.Interval
+}
+
+// GetIntervalOk returns a tuple with the Interval field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (r *Retry) GetIntervalOk() (int, bool) {
+	if r == nil || r.Interval == nil {
+		return 0, false
+	}
+	return *r.Interval, true
+}
+
+// HasInterval returns a boolean if a field has been set.
+func (r *Retry) HasInterval() bool {
+	if r != nil && r.Interval != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetInterval allocates a new r.Interval and returns the pointer to it.
+func (r *Retry) SetInterval(v int) {
+	r.Interval = &v
+}
+
 // GetColor returns the Color field if non-nil, zero value otherwise.
 func (r *Rule) GetColor() string {
 	if r == nil || r.Color == nil {
@@ -19635,6 +19697,37 @@ func (s *SyntheticsOptions) HasMinLocationFailed() bool {
 // SetMinLocationFailed allocates a new s.MinLocationFailed and returns the pointer to it.
 func (s *SyntheticsOptions) SetMinLocationFailed(v int) {
 	s.MinLocationFailed = &v
+}
+
+// GetRetry returns the Retry field if non-nil, zero value otherwise.
+func (s *SyntheticsOptions) GetRetry() Retry {
+	if s == nil || s.Retry == nil {
+		return Retry{}
+	}
+	return *s.Retry
+}
+
+// GetRetryOk returns a tuple with the Retry field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (s *SyntheticsOptions) GetRetryOk() (Retry, bool) {
+	if s == nil || s.Retry == nil {
+		return Retry{}, false
+	}
+	return *s.Retry, true
+}
+
+// HasRetry returns a boolean if a field has been set.
+func (s *SyntheticsOptions) HasRetry() bool {
+	if s != nil && s.Retry != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetRetry allocates a new s.Retry and returns the pointer to it.
+func (s *SyntheticsOptions) SetRetry(v Retry) {
+	s.Retry = &v
 }
 
 // GetTickEvery returns the TickEvery field if non-nil, zero value otherwise.

--- a/synthetics.go
+++ b/synthetics.go
@@ -58,6 +58,12 @@ type SyntheticsOptions struct {
 	MinLocationFailed  *int     `json:"min_location_failed,omitempty"`
 	DeviceIds          []string `json:"device_ids,omitempty"`
 	AcceptSelfSigned   *bool    `json:"accept_self_signed,omitempty"`
+	Retry              *Retry   `json:"retry,omitempty"`
+}
+
+type Retry struct {
+	Count    *int `json:"count,omitempty"`
+	Interval *int `json:"interval,omitempty"`
 }
 
 type SyntheticsUser struct {

--- a/synthetics_test.go
+++ b/synthetics_test.go
@@ -121,7 +121,7 @@ func TestGetSyntheticsTestApi(t *testing.T) {
 	if retry := options.GetRetry(); *retry.Count != *expectedRetry.Count {
 		t.Fatalf("expect options.retry.Count %+v. Got %+v", expectedRetry.Count, retry.Count)
 	}
-	if retry := options.GetRetry(); *retry.Count != *expectedRetry.Count {
+	if retry := options.GetRetry(); *retry.Interval != *expectedRetry.Interval {
 		t.Fatalf("expect options.retry.Interval %+v. Got %+v", expectedRetry.Interval, retry.Interval)
 	}
 

--- a/synthetics_test.go
+++ b/synthetics_test.go
@@ -117,6 +117,14 @@ func TestGetSyntheticsTestApi(t *testing.T) {
 		t.Fatalf("expect options.follow_redirects %v. Got %v", expectedFollowRedirects, followRedirects)
 	}
 
+	expectedRetry := Retry{Count: Int(1), Interval: Int(10)}
+	if retry := options.GetRetry(); *retry.Count != *expectedRetry.Count {
+		t.Fatalf("expect options.retry.Count %+v. Got %+v", expectedRetry.Count, retry.Count)
+	}
+	if retry := options.GetRetry(); *retry.Count != *expectedRetry.Count {
+		t.Fatalf("expect options.retry.Interval %+v. Got %+v", expectedRetry.Interval, retry.Interval)
+	}
+
 	locations := c.Locations
 	expectedLocationsCnt := 1
 	if cnt := len(locations); cnt != expectedLocationsCnt {

--- a/tests/fixtures/synthetics/tests/get_test_api.json
+++ b/tests/fixtures/synthetics/tests/get_test_api.json
@@ -54,6 +54,10 @@
     "tick_every": 60,
     "follow_redirects": true,
     "min_failure_duration": 30,
-    "min_location_failed": 3
+    "min_location_failed": 3,
+    "retry": {
+      "count": 1,
+      "interval": 10
+    }
   }
 }


### PR DESCRIPTION
Very simple addition to allow users to add retry logic to their Synthetics Checks.
Being that the api is missing this in their documentation. The payload was gathered via the request  posted while using the UI. Tested and is working with an in house terraform-datadog-provider.

Fixed a couple of typos too.