### PR TITLE
Adding logic to extract the Rate Limiting statistics

### DIFF
--- a/client.go
+++ b/client.go
@@ -31,12 +31,12 @@ type Client struct {
 
 	// rateLimiting is used to store the rate limitting stats.
 	// More information in the official documentation: https://docs.datadoghq.com/api/?lang=bash#rate-limiting
-	rateLimitingStats map[string]rateLimit
+	rateLimitingStats map[string]RateLimit
 	// Mutex to protect the rate limiting map.
 	m sync.Mutex
 }
 
-type rateLimit struct {
+type RateLimit struct {
 	Limit     string
 	Period    string
 	Reset     string
@@ -63,7 +63,7 @@ func NewClient(apiKey, appKey string) *Client {
 		baseUrl:           baseUrl,
 		HttpClient:        http.DefaultClient,
 		RetryTimeout:      time.Duration(60 * time.Second),
-		rateLimitingStats: make(map[string]rateLimit),
+		rateLimitingStats: make(map[string]RateLimit),
 	}
 }
 

--- a/logs_indexes_test.go
+++ b/logs_indexes_test.go
@@ -22,7 +22,7 @@ func TestLogsIndexGet(t *testing.T) {
 	client := Client{
 		baseUrl:           ts.URL,
 		HttpClient:        http.DefaultClient,
-		rateLimitingStats: make(map[string]rateLimit),
+		rateLimitingStats: make(map[string]RateLimit),
 	}
 
 	logsIndex, err := client.GetLogsIndex("main")

--- a/logs_indexes_test.go
+++ b/logs_indexes_test.go
@@ -20,8 +20,9 @@ func TestLogsIndexGet(t *testing.T) {
 	defer ts.Close()
 
 	client := Client{
-		baseUrl:    ts.URL,
-		HttpClient: http.DefaultClient,
+		baseUrl:           ts.URL,
+		HttpClient:        http.DefaultClient,
+		rateLimitingStats: make(map[string]rateLimit),
 	}
 
 	logsIndex, err := client.GetLogsIndex("main")

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -48,5 +48,10 @@ func (client *Client) updateRateLimits(resp *http.Response, api string) error {
 func (client *Client) GetRateLimitStats() map[string]RateLimit {
 	client.m.Lock()
 	defer client.m.Unlock()
-	return client.rateLimitingStats
+	// Shallow copy to avoid corrupted data
+	mapCopy := make(map[string]RateLimit, len(client.rateLimitingStats))
+	for k, v := range client.rateLimitingStats {
+		mapCopy[k] = v
+	}
+	return mapCopy
 }

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -30,8 +30,8 @@ func isRateLimited(method string, endpoint string) (limited bool, shortEndpoint 
 }
 
 func (client *Client) updateRateLimits(resp *http.Response, api string) error {
-	if resp.Header == nil {
-		return fmt.Errorf("header missing from the HTTP response.")
+	if resp == nil || resp.Header == nil {
+		return fmt.Errorf("could not parse headers from the HTTP response.")
 	}
 	client.m.Lock()
 	defer client.m.Unlock()

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -35,7 +35,7 @@ func (client *Client) updateRateLimits(resp *http.Response, api string) error {
 	}
 	client.m.Lock()
 	defer client.m.Unlock()
-	client.rateLimitingStats[api] = rateLimit{
+	client.rateLimitingStats[api] = RateLimit{
 		Limit:     resp.Header.Get("X-RateLimit-Limit"),
 		Reset:     resp.Header.Get("X-RateLimit-Reset"),
 		Period:    resp.Header.Get("X-RateLimit-Period"),
@@ -45,7 +45,7 @@ func (client *Client) updateRateLimits(resp *http.Response, api string) error {
 }
 
 // GetRateLimitStats is a threadsafe getter to retrieve the rate limiting stats associated with the Client.
-func (client *Client) GetRateLimitStats() map[string]rateLimit {
+func (client *Client) GetRateLimitStats() map[string]RateLimit {
 	client.m.Lock()
 	defer client.m.Unlock()
 	return client.rateLimitingStats

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -1,0 +1,52 @@
+package datadog
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// The list of Rate Limited Endpoints of the Datadog API.
+// https://docs.datadoghq.com/api/?lang=bash#rate-limiting
+var (
+	rateLimitedEndpoints = map[string]string{
+		"/v1/query":               "GET",
+		"/v1/input":               "GET",
+		"/v1/metrics":             "GET",
+		"/v1/events":              "POST",
+		"/v1/logs-queries/list":   "POST",
+		"/v1/graph/snapshot":      "GET",
+		"/v1/logs/config/indexes": "GET",
+	}
+)
+
+func isRateLimited(method string, endpoint string) (limited bool, shortEndpoint string) {
+	for e, m := range rateLimitedEndpoints {
+		if strings.HasPrefix(endpoint, e) && m == method {
+			return true, e
+		}
+	}
+	return false, ""
+}
+
+func (client *Client) updateRateLimits(resp *http.Response, api string) error {
+	if resp.Header == nil {
+		return fmt.Errorf("header missing from the HTTP response.")
+	}
+	client.m.Lock()
+	defer client.m.Unlock()
+	client.rateLimitingStats[api] = rateLimit{
+		Limit:     resp.Header.Get("X-RateLimit-Limit"),
+		Reset:     resp.Header.Get("X-RateLimit-Reset"),
+		Period:    resp.Header.Get("X-RateLimit-Period"),
+		Remaining: resp.Header.Get("X-RateLimit-Remaining"),
+	}
+	return nil
+}
+
+// GetRateLimitStats is a threadsafe getter to retrieve the rate limiting stats associated with the Client.
+func (client *Client) GetRateLimitStats() map[string]rateLimit {
+	client.m.Lock()
+	defer client.m.Unlock()
+	return client.rateLimitingStats
+}

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -3,39 +3,22 @@ package datadog
 import (
 	"fmt"
 	"net/http"
-	"strings"
+	"net/url"
 )
 
 // The list of Rate Limited Endpoints of the Datadog API.
 // https://docs.datadoghq.com/api/?lang=bash#rate-limiting
-var (
-	rateLimitedEndpoints = map[string]string{
-		"/v1/query":               "GET",
-		"/v1/input":               "GET",
-		"/v1/metrics":             "GET",
-		"/v1/events":              "POST",
-		"/v1/logs-queries/list":   "POST",
-		"/v1/graph/snapshot":      "GET",
-		"/v1/logs/config/indexes": "GET",
+func (client *Client) updateRateLimits(resp *http.Response, api *url.URL) error {
+	if resp == nil || resp.Header == nil || api.Path == "" {
+		return fmt.Errorf("malformed HTTP content.")
 	}
-)
-
-func isRateLimited(method string, endpoint string) (limited bool, shortEndpoint string) {
-	for e, m := range rateLimitedEndpoints {
-		if strings.HasPrefix(endpoint, e) && m == method {
-			return true, e
-		}
-	}
-	return false, ""
-}
-
-func (client *Client) updateRateLimits(resp *http.Response, api string) error {
-	if resp == nil || resp.Header == nil {
-		return fmt.Errorf("could not parse headers from the HTTP response.")
+	if resp.Header.Get("X-RateLimit-Remaining") == "" {
+		// The endpoint is not Rate Limited.
+		return nil
 	}
 	client.m.Lock()
 	defer client.m.Unlock()
-	client.rateLimitingStats[api] = RateLimit{
+	client.rateLimitingStats[api.Path] = RateLimit{
 		Limit:     resp.Header.Get("X-RateLimit-Limit"),
 		Reset:     resp.Header.Get("X-RateLimit-Reset"),
 		Period:    resp.Header.Get("X-RateLimit-Period"),

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -49,48 +49,48 @@ func Test_isRateLimited(t *testing.T) {
 func Test_updateRateLimits(t *testing.T) {
 	// fake client to ensure that we are race free.
 	client := Client{
-		rateLimitingStats: make(map[string]rateLimit),
+		rateLimitingStats: make(map[string]RateLimit),
 	}
 	tests := []struct {
 		desc   string
 		api    string
 		resp   *http.Response
-		header rateLimit
+		header RateLimit
 		error  error
 	}{
 		{
 			"nominal case query",
 			"/v1/query",
 			makeHeader("1", "2", "3", "4"),
-			rateLimit{"1", "2", "3", "4"},
+			RateLimit{"1", "2", "3", "4"},
 			nil,
 		},
 		{
 			"nominal case logs",
 			"/v1/logs-queries/list",
 			makeHeader("2", "2", "1", "5"),
-			rateLimit{"2", "2", "1", "5"},
+			RateLimit{"2", "2", "1", "5"},
 			nil,
 		},
 		{
 			"no response",
 			"",
 			nil,
-			rateLimit{},
+			RateLimit{},
 			fmt.Errorf("could not parse headers from the HTTP response."),
 		},
 		{
 			"no header",
 			"/v2/error",
 			makeEmptyHeader(),
-			rateLimit{},
+			RateLimit{},
 			fmt.Errorf("could not parse headers from the HTTP response."),
 		},
 		{
 			"update case query",
 			"/v1/query",
 			makeHeader("2", "4", "6", "4"),
-			rateLimit{"2", "4", "6", "4"},
+			RateLimit{"2", "4", "6", "4"},
 			nil,
 		},
 	}

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -1,0 +1,122 @@
+package datadog
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
+func Test_isRateLimited(t *testing.T) {
+	tests := []struct {
+		desc             string
+		endpoint         string
+		method           string
+		isRateLimited    bool
+		endpointFormated string
+	}{
+		{
+			desc:             "is rate limited",
+			endpoint:         "/v1/query?&query=avg:system.cpu.user{*}by{host}",
+			method:           "GET",
+			isRateLimited:    true,
+			endpointFormated: "/v1/query",
+		},
+		{
+			desc:             "is not rate limited",
+			endpoint:         "/v1/series?api_key=12",
+			method:           "POST",
+			isRateLimited:    false,
+			endpointFormated: "",
+		},
+		{
+			desc:             "is rate limited but wrong method",
+			endpoint:         "/v1/query?&query=avg:system.cpu.user{*}by{host}",
+			method:           "POST",
+			isRateLimited:    false,
+			endpointFormated: "",
+		},
+	}
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("#%d %s", i, tt.desc), func(t *testing.T) {
+			limited, edpt := isRateLimited(tt.method, tt.endpoint)
+			assert.Equal(t, limited, tt.isRateLimited)
+			assert.Equal(t, edpt, tt.endpointFormated)
+		})
+	}
+}
+
+func Test_updateRateLimits(t *testing.T) {
+	// fake client to ensure that we are race free.
+	client := Client{
+		rateLimitingStats: make(map[string]rateLimit),
+	}
+	tests := []struct {
+		desc   string
+		api    string
+		resp   *http.Response
+		header rateLimit
+		error  error
+	}{
+		{
+			"nominal case query",
+			"/v1/query",
+			makeHeader("1", "2", "3", "4"),
+			rateLimit{"1", "2", "3", "4"},
+			nil,
+		},
+		{
+			"nominal case logs",
+			"/v1/logs-queries/list",
+			makeHeader("2", "2", "1", "5"),
+			rateLimit{"2", "2", "1", "5"},
+			nil,
+		},
+		{
+			"no response",
+			"",
+			nil,
+			rateLimit{},
+			fmt.Errorf("could not parse headers from the HTTP response."),
+		},
+		{
+			"no header",
+			"/v2/error",
+			makeEmptyHeader(),
+			rateLimit{},
+			fmt.Errorf("could not parse headers from the HTTP response."),
+		},
+		{
+			"update case query",
+			"/v1/query",
+			makeHeader("2", "4", "6", "4"),
+			rateLimit{"2", "4", "6", "4"},
+			nil,
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("#%d %s", i, tt.desc), func(t *testing.T) {
+			err := client.updateRateLimits(tt.resp, tt.api)
+			assert.Equal(t, tt.error, err)
+			assert.Equal(t, tt.header, client.rateLimitingStats[tt.api])
+		})
+	}
+}
+
+func makeHeader(limit, period, reset, remaining string) *http.Response {
+	h := http.Response{
+		Header: make(map[string][]string),
+	}
+	h.Header.Set("X-RateLimit-Limit", limit)
+	h.Header.Set("X-RateLimit-Reset", reset)
+	h.Header.Set("X-RateLimit-Period", period)
+	h.Header.Set("X-RateLimit-Remaining", remaining)
+	return &h
+}
+
+func makeEmptyHeader() *http.Response {
+	return &http.Response{
+		Header: nil,
+	}
+}

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -61,14 +61,14 @@ func Test_updateRateLimits(t *testing.T) {
 		{
 			"nominal case query",
 			"/v1/query",
-			makeHeader("1", "2", "3", "4"),
+			makeHeader(RateLimit{"1", "2", "3", "4"}),
 			RateLimit{"1", "2", "3", "4"},
 			nil,
 		},
 		{
 			"nominal case logs",
 			"/v1/logs-queries/list",
-			makeHeader("2", "2", "1", "5"),
+			makeHeader(RateLimit{"2", "2", "1", "5"}),
 			RateLimit{"2", "2", "1", "5"},
 			nil,
 		},
@@ -89,7 +89,7 @@ func Test_updateRateLimits(t *testing.T) {
 		{
 			"update case query",
 			"/v1/query",
-			makeHeader("2", "4", "6", "4"),
+			makeHeader(RateLimit{"2", "4", "6", "4"}),
 			RateLimit{"2", "4", "6", "4"},
 			nil,
 		},
@@ -104,14 +104,14 @@ func Test_updateRateLimits(t *testing.T) {
 	}
 }
 
-func makeHeader(limit, period, reset, remaining string) *http.Response {
+func makeHeader(r RateLimit) *http.Response {
 	h := http.Response{
 		Header: make(map[string][]string),
 	}
-	h.Header.Set("X-RateLimit-Limit", limit)
-	h.Header.Set("X-RateLimit-Reset", reset)
-	h.Header.Set("X-RateLimit-Period", period)
-	h.Header.Set("X-RateLimit-Remaining", remaining)
+	h.Header.Set("X-RateLimit-Limit", r.Limit)
+	h.Header.Set("X-RateLimit-Reset", r.Reset)
+	h.Header.Set("X-RateLimit-Period", r.Period)
+	h.Header.Set("X-RateLimit-Remaining", r.Remaining)
 	return &h
 }
 

--- a/request.go
+++ b/request.go
@@ -122,7 +122,6 @@ func (client *Client) doJsonRequestUnredacted(method, api string,
 	if err != nil {
 		return err
 	}
-
 	// Perform the request and retry it if it's not a POST or PUT request
 	var resp *http.Response
 	if method == "POST" || method == "PUT" {
@@ -154,13 +153,10 @@ func (client *Client) doJsonRequestUnredacted(method, api string,
 		body = []byte{'{', '}'}
 	}
 
-	limited, short := isRateLimited(method, api)
-	if limited {
-		err := client.updateRateLimits(resp, short)
-		if err != nil {
-			// Inability to update the rate limiting stats should not be a blocking error.
-			fmt.Printf("Error Updating the Rate Limit statistics: %s", err.Error())
-		}
+	err = client.updateRateLimits(resp, req.URL)
+	if err != nil {
+		// Inability to update the rate limiting stats should not be a blocking error.
+		fmt.Printf("Error Updating the Rate Limit statistics: %s", err.Error())
 	}
 
 	// Try to parse common response fields to check whether there's an error reported in a response.

--- a/request.go
+++ b/request.go
@@ -159,7 +159,7 @@ func (client *Client) doJsonRequestUnredacted(method, api string,
 		err := client.updateRateLimits(resp, short)
 		if err != nil {
 			// Inability to update the rate limiting stats should not be a blocking error.
-			fmt.Errorf("Error Updating the Rate Limit statistics: %s", err.Error())
+			fmt.Printf("Error Updating the Rate Limit statistics: %s", err.Error())
 		}
 	}
 

--- a/request.go
+++ b/request.go
@@ -154,6 +154,15 @@ func (client *Client) doJsonRequestUnredacted(method, api string,
 		body = []byte{'{', '}'}
 	}
 
+	limited, short := isRateLimited(method, api)
+	if limited {
+		err := client.updateRateLimits(resp, short)
+		if err != nil {
+			// Inability to update the rate limiting stats should not be a blocking error.
+			fmt.Errorf("Error Updating the Rate Limit statistics: %s", err.Error())
+		}
+	}
+
 	// Try to parse common response fields to check whether there's an error reported in a response.
 	var common *Response
 	err = json.Unmarshal(body, &common)


### PR DESCRIPTION
In an effort to give maximum visibility over the communication between the client and the backend, we would like to introduce logic to extract the Rate Limiting stats from the header of calls made to rate limited endpoints.
More details in the[ official API doc](https://docs.datadoghq.com/api/?lang=bash#rate-limiting).

It exposes a thread safe public method to get the values. 
Additionally, we update the map associated with the Client in the method closest to the request to ensure that we don't miss calls.
