### PR TITLE
Add support for Template Variable Presets for Boards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ testrace:
 	go test -race $(TEST) $(TESTARGS)
 
 fmt:
-	gofmt -w $(GOFMT_FILES)
+	gofmt -w -s $(GOFMT_FILES)
 
 # vet runs the Go source code static analysis tool `vet` to find
 # any common errors.

--- a/boards.go
+++ b/boards.go
@@ -12,21 +12,35 @@ import (
 	"fmt"
 )
 
+// Template variable preset represents a set of template variable values on a dashboard
+// Not available to timeboards and screenboards
+type TemplateVariablePreset struct {
+	Name              *string                       `json:"name,omitempty"`
+	TemplateVariables []TemplateVariablePresetValue `json:"template_variables"`
+}
+
+// Template variable preset value represents the value for "name" template variable to assume
+type TemplateVariablePresetValue struct {
+	Name  *string `json:"name,omitempty"`
+	Value *string `json:"value,omitempty"`
+}
+
 // Board represents a user created dashboard. This is the full dashboard
 // struct when we load a dashboard in detail.
 type Board struct {
-	Title             *string            `json:"title"`
-	Widgets           []BoardWidget      `json:"widgets"`
-	LayoutType        *string            `json:"layout_type"`
-	Id                *string            `json:"id,omitempty"`
-	Description       *string            `json:"description,omitempty"`
-	TemplateVariables []TemplateVariable `json:"template_variables,omitempty"`
-	IsReadOnly        *bool              `json:"is_read_only,omitempty"`
-	NotifyList        []string           `json:"notify_list,omitempty"`
-	AuthorHandle      *string            `json:"author_handle,omitempty"`
-	Url               *string            `json:"url,omitempty"`
-	CreatedAt         *string            `json:"created_at,omitempty"`
-	ModifiedAt        *string            `json:"modified_at,omitempty"`
+	Title                   *string                  `json:"title"`
+	Widgets                 []BoardWidget            `json:"widgets"`
+	LayoutType              *string                  `json:"layout_type"`
+	Id                      *string                  `json:"id,omitempty"`
+	Description             *string                  `json:"description,omitempty"`
+	TemplateVariables       []TemplateVariable       `json:"template_variables,omitempty"`
+	TemplateVariablePresets []TemplateVariablePreset `json:"template_variable_presets,omitempty"`
+	IsReadOnly              *bool                    `json:"is_read_only,omitempty"`
+	NotifyList              []string                 `json:"notify_list,omitempty"`
+	AuthorHandle            *string                  `json:"author_handle,omitempty"`
+	Url                     *string                  `json:"url,omitempty"`
+	CreatedAt               *string                  `json:"created_at,omitempty"`
+	ModifiedAt              *string                  `json:"modified_at,omitempty"`
 }
 
 // BoardLite represents a simplify dashboard (without widgets, notify list, ...)

--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -4,7 +4,7 @@
  *
  * Please see the included LICENSE file for licensing information.
  *
- * Copyright 2019 by authors and contributors.
+ * Copyright 2020 by authors and contributors.
 */
 
 package datadog
@@ -20007,6 +20007,99 @@ func (t *TemplateVariable) HasPrefix() bool {
 // SetPrefix allocates a new t.Prefix and returns the pointer to it.
 func (t *TemplateVariable) SetPrefix(v string) {
 	t.Prefix = &v
+}
+
+// GetName returns the Name field if non-nil, zero value otherwise.
+func (t *TemplateVariablePreset) GetName() string {
+	if t == nil || t.Name == nil {
+		return ""
+	}
+	return *t.Name
+}
+
+// GetNameOk returns a tuple with the Name field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TemplateVariablePreset) GetNameOk() (string, bool) {
+	if t == nil || t.Name == nil {
+		return "", false
+	}
+	return *t.Name, true
+}
+
+// HasName returns a boolean if a field has been set.
+func (t *TemplateVariablePreset) HasName() bool {
+	if t != nil && t.Name != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetName allocates a new t.Name and returns the pointer to it.
+func (t *TemplateVariablePreset) SetName(v string) {
+	t.Name = &v
+}
+
+// GetName returns the Name field if non-nil, zero value otherwise.
+func (t *TemplateVariablePresetValue) GetName() string {
+	if t == nil || t.Name == nil {
+		return ""
+	}
+	return *t.Name
+}
+
+// GetNameOk returns a tuple with the Name field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TemplateVariablePresetValue) GetNameOk() (string, bool) {
+	if t == nil || t.Name == nil {
+		return "", false
+	}
+	return *t.Name, true
+}
+
+// HasName returns a boolean if a field has been set.
+func (t *TemplateVariablePresetValue) HasName() bool {
+	if t != nil && t.Name != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetName allocates a new t.Name and returns the pointer to it.
+func (t *TemplateVariablePresetValue) SetName(v string) {
+	t.Name = &v
+}
+
+// GetValue returns the Value field if non-nil, zero value otherwise.
+func (t *TemplateVariablePresetValue) GetValue() string {
+	if t == nil || t.Value == nil {
+		return ""
+	}
+	return *t.Value
+}
+
+// GetValueOk returns a tuple with the Value field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (t *TemplateVariablePresetValue) GetValueOk() (string, bool) {
+	if t == nil || t.Value == nil {
+		return "", false
+	}
+	return *t.Value, true
+}
+
+// HasValue returns a boolean if a field has been set.
+func (t *TemplateVariablePresetValue) HasValue() bool {
+	if t != nil && t.Value != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetValue allocates a new t.Value and returns the pointer to it.
+func (t *TemplateVariablePresetValue) SetValue(v string) {
+	t.Value = &v
 }
 
 // GetCritical returns the Critical field if non-nil, zero value otherwise.

--- a/integration/boards_test.go
+++ b/integration/boards_test.go
@@ -70,12 +70,12 @@ func getTestBoardWithTemplateVars() *datadog.Board {
 
 func getTestTemplateVars() []datadog.TemplateVariable {
 	return []datadog.TemplateVariable{
-		datadog.TemplateVariable{
+		{
 			Name:    datadog.String("Template Var 1"),
 			Prefix:  datadog.String("var1"),
 			Default: datadog.String("value1"),
 		},
-		datadog.TemplateVariable{
+		{
 			Name:   datadog.String("Template Var 2"),
 			Prefix: datadog.String("var2"),
 		},
@@ -84,23 +84,23 @@ func getTestTemplateVars() []datadog.TemplateVariable {
 
 func getTestTemplateVarPresets() []datadog.TemplateVariablePreset {
 	return []datadog.TemplateVariablePreset{
-		datadog.TemplateVariablePreset{
+		{
 			Name: datadog.String("Preset 1"),
 			TemplateVariables: []datadog.TemplateVariablePresetValue{
-				datadog.TemplateVariablePresetValue{
+				{
 					Name:  datadog.String("Template Var 1"),
 					Value: datadog.String("Preset 1 Var 1"),
 				},
-				datadog.TemplateVariablePresetValue{
+				{
 					Name:  datadog.String("Template Var 2"),
 					Value: datadog.String("Preset 1 Var 2"),
 				},
 			},
 		},
-		datadog.TemplateVariablePreset{
+		{
 			Name: datadog.String("Preset 2"),
 			TemplateVariables: []datadog.TemplateVariablePresetValue{
-				datadog.TemplateVariablePresetValue{
+				{
 					Name:  datadog.String("Template Var 1"),
 					Value: datadog.String("Preset 2 Var 1"),
 				},

--- a/integration/dashboards_test.go
+++ b/integration/dashboards_test.go
@@ -26,7 +26,6 @@ func TestDashboardCreateAndDeleteAdvancesTimeseries(t *testing.T) {
 		t.Fatalf("Retrieving a dashboard failed when it shouldn't. (%s)", err)
 	}
 	assertDashboardEquals(t, actual, expected)
-
 }
 
 func TestDashboardUpdate(t *testing.T) {
@@ -195,6 +194,7 @@ func TestDashboardGetWithNewId(t *testing.T) {
 		assert.Contains(t, err.Error(), "unsupported id type")
 	}
 }
+
 func createTestDashboard(t *testing.T) *datadog.Dashboard {
 	board := getTestDashboard(createGraph)
 	board, err := client.CreateDashboard(board)


### PR DESCRIPTION
 ## What

<img width="625" alt="image"
src="https://user-images.githubusercontent.com/6370918/71746068-9073ba00-2e31-11ea-83c5-8498d3a14cb8.png">

"Template Variable Presets" aka "Saved Views" are a quick shortcut that
can be added by hand or via json to dashboards in datadog, and appear in
the top left corner.

They allow you to string together common combinations of template
variable values, so if for example you want a "production us-east-2"
view of your dashboard, you could have a "production us-east-2" preset
that sets your template variables to `environment = production` and
`region = us-east-2`.

This PR adds support for template variable presets to Boards (aka
dashboards, not to be confused with screenboards or timeboards, which
are not supported by the API). This will be a necessary step towards
adding template variable preset support to the [datadog terraform
provider](https://github.com/terraform-providers/terraform-provider-datadog).

Cheers!