### PR TITLE
add query table to screen widgets comments

### DIFF
--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -4,7 +4,7 @@
  *
  * Please see the included LICENSE file for licensing information.
  *
- * Copyright 2019 by authors and contributors.
+ * Copyright 2020 by authors and contributors.
 */
 
 package datadog

--- a/screen_widgets.go
+++ b/screen_widgets.go
@@ -165,7 +165,7 @@ type Widget struct {
 	// For Timeseries, TopList, EventTimeline, EvenStream, AlertGraph, CheckStatus, ServiceSummary, LogStream widgets
 	Time *Time `json:"time,omitempty"`
 
-	// For Timeseries, QueryValue, HostMap, Change, Toplist, Process widgets
+	// For Timeseries, QueryValue, QueryTable, HostMap, Change, Toplist, Process widgets
 	TileDef *TileDef `json:"tile_def,omitempty"`
 
 	// For FreeText widget
@@ -180,7 +180,7 @@ type Widget struct {
 	// AlertGraph widget
 	VizType *string `json:"viz_type,omitempty"`
 
-	// For AlertValue, QueryValue, FreeText, Note widgets
+	// For AlertValue, QueryValue, QueryTable, FreeText, Note widgets
 	TextAlign *string `json:"text_align,omitempty"`
 
 	// For FreeText, Note widgets
@@ -190,7 +190,7 @@ type Widget struct {
 	AlertID     *int  `json:"alert_id,omitempty"`
 	AutoRefresh *bool `json:"auto_refresh,omitempty"`
 
-	// For Timeseries, QueryValue, Toplist widgets
+	// For Timeseries, QueryValue, QueryTable, Toplist widgets
 	Legend     *bool   `json:"legend,omitempty"`
 	LegendSize *string `json:"legend_size,omitempty"`
 


### PR DESCRIPTION
Adding these comments was requested in a separate feature request [here](https://github.com/terraform-providers/terraform-provider-datadog/issues/292#issuecomment-569274137). There is also an open pull request for adding the `QueryTable` widget [here](https://github.com/terraform-providers/terraform-provider-datadog/pull/373).