### PR TITLE
Fix client.ExtraHeader initialisation in NewClient()

### DIFF
--- a/client.go
+++ b/client.go
@@ -64,6 +64,7 @@ func NewClient(apiKey, appKey string) *Client {
 		HttpClient:        http.DefaultClient,
 		RetryTimeout:      time.Duration(60 * time.Second),
 		rateLimitingStats: make(map[string]RateLimit),
+		ExtraHeader:       make(map[string]string),
 	}
 }
 

--- a/integration/client_test.go
+++ b/integration/client_test.go
@@ -59,3 +59,11 @@ func TestExtraHeader(t *testing.T) {
 		assert.Empty(t, c.ExtraHeader)
 	})
 }
+
+func TestInsertExtraHeader(t *testing.T) {
+	t.Run("ExtraHeader map should be initialised", func(t *testing.T) {
+		c := datadog.NewClient("foo", "bar")
+		c.ExtraHeader["foo"] = "bar"
+		assert.Equal(t, c.ExtraHeader["foo"], "bar")
+	})
+}


### PR DESCRIPTION
The `client.ExtraHeader` map wasn't initialised in the `NewClient()` function.