### PR TITLE
Change ServiceLevelObjectiveHistory Uptime to SliValue

### DIFF
--- a/service_level_objectives.go
+++ b/service_level_objectives.go
@@ -525,7 +525,7 @@ type ServiceLevelObjectiveHistoryMetricSeries struct {
 
 // ServiceLevelObjectiveHistoryMonitorSeries defines the SLO history data response for `monitor` type SLOs
 type ServiceLevelObjectiveHistoryMonitorSeries struct {
-	Uptime        float32                                   `json:"uptime"`
+	SliValue      float32                                   `json:"sli_value"`
 	SpanPrecision json.Number                               `json:"span_precision"`
 	Name          string                                    `json:"name"`
 	Precision     map[string]json.Number                    `json:"precision"`
@@ -536,7 +536,7 @@ type ServiceLevelObjectiveHistoryMonitorSeries struct {
 // ServiceLevelObjectiveHistoryOverall defines the overall SLO history data response
 // for `monitor` type SLOs there is an additional `History` property that rolls up the overall state correctly.
 type ServiceLevelObjectiveHistoryOverall struct {
-	Uptime        float32                `json:"uptime"`
+	SliValue      float32                `json:"sli_value"`
 	SpanPrecision json.Number            `json:"span_precision"`
 	Name          string                 `json:"name"`
 	Precision     map[string]json.Number `json:"precision"`

--- a/service_level_objectives_test.go
+++ b/service_level_objectives_test.go
@@ -334,7 +334,7 @@ func TestServiceLevelObjectiveIntegration(t *testing.T) {
 
 		assert.NoError(t2, err)
 		assert.Nil(t2, resp.Error)
-		assert.Equal(t2, float32(100), resp.Data.Overall.Uptime)
+		assert.Equal(t2, float32(100), resp.Data.Overall.SliValue)
 		assert.Equal(t2, json.Number("3698988"), resp.Data.Metrics.Numerator.Sum)
 		assert.Equal(t2, json.Number("3698988"), resp.Data.Metrics.Denominator.Sum)
 	})
@@ -350,9 +350,9 @@ func TestServiceLevelObjectiveIntegration(t *testing.T) {
 		)
 		assert.NoError(t2, err)
 		assert.Nil(t2, resp.Error)
-		assert.Equal(t2, float32(6.765872955322266), resp.Data.Overall.Uptime)
+		assert.Equal(t2, float32(6.765872955322266), resp.Data.Overall.SliValue)
 		assert.Len(t2, resp.Data.Groups, 1)
-		assert.Equal(t2, float32(6.765872955322266), resp.Data.Groups[0].Uptime)
+		assert.Equal(t2, float32(6.765872955322266), resp.Data.Groups[0].SliValue)
 		assert.Equal(t2, "some:tag", resp.Data.Groups[0].Name)
 	})
 

--- a/tests/fixtures/service_level_objectives/get_history_metric_response.json
+++ b/tests/fixtures/service_level_objectives/get_history_metric_response.json
@@ -77,7 +77,7 @@
       }
     },
     "overall": {
-      "uptime": 100,
+      "sli_value": 100,
       "span_precision": 0,
       "precision": {
         "7d": 0,

--- a/tests/fixtures/service_level_objectives/get_history_monitor_response.json
+++ b/tests/fixtures/service_level_objectives/get_history_monitor_response.json
@@ -10,7 +10,7 @@
       }
     },
     "overall": {
-      "uptime": 6.765872955322266,
+      "sli_value": 6.765872955322266,
       "span_precision": 2,
       "name": "test uptime",
       "precision": {
@@ -587,7 +587,7 @@
     "from_ts": 1571162100,
     "groups": [
       {
-        "uptime": 6.765872955322266,
+        "sli_value": 6.765872955322266,
         "span_precision": 2,
         "name": "some:tag",
         "precision": {


### PR DESCRIPTION
It seems that the uptime of SLO history API was changed to sli_value.

```
## Monitor Based
{
  "data": {
  ...
    "overall": {
      "sli_value": 99.04629516601562,
  ...
  "groups": [
      {
        "sli_value": 99.68518829345703,
        ...
      }
  ]
}
```

```
## Event Based
{
  "data": {
    ...
    "overall": {
      "sli_value": 100,
      ...
    }
    ...
  }
}
```

API doc: https://docs.datadoghq.com/api/?lang=bash#get-an-slo-s-history
This PR changes the value of ServiceLevelObjectiveHistory structs from uptime to sli_value.