### PR TITLE
update widget id to int64

### DIFF
--- a/board_widgets.go
+++ b/board_widgets.go
@@ -43,7 +43,7 @@ const (
 // different according to widget type.
 type BoardWidget struct {
 	Definition interface{}   `json:"definition"`
-	Id         *int          `json:"id,omitempty"`
+	Id         *int64        `json:"id,omitempty"`
 	Layout     *WidgetLayout `json:"layout,omitempty"`
 }
 
@@ -515,7 +515,7 @@ func (widget *BoardWidget) UnmarshalJSON(data []byte) error {
 		Definition *struct {
 			Type *string `json:"type"`
 		} `json:"definition"`
-		Id     *int          `json:"id,omitempty"`
+		Id     *int64        `json:"id,omitempty"`
 		Layout *WidgetLayout `json:"layout,omitempty"`
 	}
 	if err := json.Unmarshal(data, &widgetHandler); err != nil {

--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -2061,7 +2061,7 @@ func (b *BoardLite) SetUrl(v string) {
 }
 
 // GetId returns the Id field if non-nil, zero value otherwise.
-func (b *BoardWidget) GetId() int {
+func (b *BoardWidget) GetId() int64 {
 	if b == nil || b.Id == nil {
 		return 0
 	}
@@ -2070,7 +2070,7 @@ func (b *BoardWidget) GetId() int {
 
 // GetIdOk returns a tuple with the Id field if it's non-nil, zero value otherwise
 // and a boolean to check if the value has been set.
-func (b *BoardWidget) GetIdOk() (int, bool) {
+func (b *BoardWidget) GetIdOk() (int64, bool) {
 	if b == nil || b.Id == nil {
 		return 0, false
 	}
@@ -2087,7 +2087,7 @@ func (b *BoardWidget) HasId() bool {
 }
 
 // SetId allocates a new b.Id and returns the pointer to it.
-func (b *BoardWidget) SetId(v int) {
+func (b *BoardWidget) SetId(v int64) {
 	b.Id = &v
 }
 


### PR DESCRIPTION
Datadog is generating larger widget IDs that int32 can't hold.

https://github.com/terraform-providers/terraform-provider-datadog/issues/459
https://github.com/zorkian/go-datadog-api/issues/314

example widget ID given to me by Datadog: Widget ID: 2906216754218349

int64 can hold this number fine