### PR TITLE
Add Indexes array to Log Stream Widget

### DIFF
--- a/board_widgets.go
+++ b/board_widgets.go
@@ -304,6 +304,7 @@ type ImageDefinition struct {
 type LogStreamDefinition struct {
 	Type              *string          `json:"type"`
 	Logset            *string          `json:"logset"`
+	Indexes           []string         `json:"indexes,omitempty"`
 	Query             *string          `json:"query,omitempty"`
 	Columns           []string         `json:"columns,omitempty"`
 	Title             *string          `json:"title,omitempty"`

--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -26395,6 +26395,37 @@ func (w *Widget) SetHTML(v string) {
 	w.HTML = &v
 }
 
+// GetIndexes returns the Indexes field if non-nil, zero value otherwise.
+func (w *Widget) GetIndexes() string {
+	if w == nil || w.Indexes == nil {
+		return ""
+	}
+	return *w.Indexes
+}
+
+// GetIndexesOk returns a tuple with the Indexes field if it's non-nil, zero value otherwise
+// and a boolean to check if the value has been set.
+func (w *Widget) GetIndexesOk() (string, bool) {
+	if w == nil || w.Indexes == nil {
+		return "", false
+	}
+	return *w.Indexes, true
+}
+
+// HasIndexes returns a boolean if a field has been set.
+func (w *Widget) HasIndexes() bool {
+	if w != nil && w.Indexes != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetIndexes allocates a new w.Indexes and returns the pointer to it.
+func (w *Widget) SetIndexes(v string) {
+	w.Indexes = &v
+}
+
 // GetLayoutVersion returns the LayoutVersion field if non-nil, zero value otherwise.
 func (w *Widget) GetLayoutVersion() string {
 	if w == nil || w.LayoutVersion == nil {

--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -26395,37 +26395,6 @@ func (w *Widget) SetHTML(v string) {
 	w.HTML = &v
 }
 
-// GetIndexes returns the Indexes field if non-nil, zero value otherwise.
-func (w *Widget) GetIndexes() string {
-	if w == nil || w.Indexes == nil {
-		return ""
-	}
-	return *w.Indexes
-}
-
-// GetIndexesOk returns a tuple with the Indexes field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (w *Widget) GetIndexesOk() (string, bool) {
-	if w == nil || w.Indexes == nil {
-		return "", false
-	}
-	return *w.Indexes, true
-}
-
-// HasIndexes returns a boolean if a field has been set.
-func (w *Widget) HasIndexes() bool {
-	if w != nil && w.Indexes != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetIndexes allocates a new w.Indexes and returns the pointer to it.
-func (w *Widget) SetIndexes(v string) {
-	w.Indexes = &v
-}
-
 // GetLayoutVersion returns the LayoutVersion field if non-nil, zero value otherwise.
 func (w *Widget) GetLayoutVersion() string {
 	if w == nil || w.LayoutVersion == nil {

--- a/integration/screen_widgets_test.go
+++ b/integration/screen_widgets_test.go
@@ -497,7 +497,28 @@ func TestWidgets(t *testing.T) {
 			Query:   datadog.String("source:main"),
 			Columns: datadog.String("[\"column_1\",\"column_2\",\"column_3\"]"),
 			Logset:  datadog.String("1234"),
-			Indexes: datadog.String("[\"main\"]"),
+			Time: &datadog.Time{
+				LiveSpan: datadog.String("1h"),
+			},
+			ShowDateColumn:    datadog.Bool(true),
+			ShowMessageColumn: datadog.Bool(true),
+			MessageDisplay:    datadog.String("expanded-lg"),
+			Sort: &datadog.WidgetFieldSort{
+				Column: datadog.String("column_1"),
+				Order:  datadog.String("asc"),
+			},
+		},
+		{
+			Type:    datadog.String("log_stream"),
+			X:       datadog.Int(1),
+			Y:       datadog.Int(1),
+			Width:   datadog.Int(5),
+			Height:  datadog.Int(5),
+			Query:   datadog.String("source:main"),
+			Columns: datadog.String("[\"column_1\",\"column_2\",\"column_3\"]"),
+			Indexes: []*string{
+				datadog.String("main"),
+			},
 			Time: &datadog.Time{
 				LiveSpan: datadog.String("1h"),
 			},

--- a/integration/screen_widgets_test.go
+++ b/integration/screen_widgets_test.go
@@ -497,6 +497,7 @@ func TestWidgets(t *testing.T) {
 			Query:   datadog.String("source:main"),
 			Columns: datadog.String("[\"column_1\",\"column_2\",\"column_3\"]"),
 			Logset:  datadog.String("1234"),
+			Indexes: datadog.String("[\"main\"]"),
 			Time: &datadog.Time{
 				LiveSpan: datadog.String("1h"),
 			},

--- a/screen_widgets.go
+++ b/screen_widgets.go
@@ -252,6 +252,7 @@ type Widget struct {
 	// For LogStream widget
 	Columns           *string          `json:"columns,omitempty"`
 	Logset            *string          `json:"logset,omitempty"`
+	Indexes           []*string        `json:"indexes,omitempty"`
 	ShowDateColumn    *bool            `json:"show_date_column,omitempty"`
 	ShowMessageColumn *bool            `json:"show_message_column,omitempty"`
 	MessageDisplay    *string          `json:"message_display,omitempty"`


### PR DESCRIPTION
add: Indexes array to LogStreamDefinition(board_widgets.go) and Widget(screen_widgets.go). Update integration test.

According to https://docs.datadoghq.com/dashboards/widgets/log_stream/
logset is Deprecated and indexes should be used. #317