### PR TITLE
Add SearchMonitors to monitors.go

### DIFF
--- a/datadog-accessors.go
+++ b/datadog-accessors.go
@@ -14150,37 +14150,6 @@ func (m *Monitor) SetOverallState(v string) {
 	m.OverallState = &v
 }
 
-// GetOverallStateModified returns the OverallStateModified field if non-nil, zero value otherwise.
-func (m *Monitor) GetOverallStateModified() string {
-	if m == nil || m.OverallStateModified == nil {
-		return ""
-	}
-	return *m.OverallStateModified
-}
-
-// GetOverallStateModifiedOk returns a tuple with the OverallStateModified field if it's non-nil, zero value otherwise
-// and a boolean to check if the value has been set.
-func (m *Monitor) GetOverallStateModifiedOk() (string, bool) {
-	if m == nil || m.OverallStateModified == nil {
-		return "", false
-	}
-	return *m.OverallStateModified, true
-}
-
-// HasOverallStateModified returns a boolean if a field has been set.
-func (m *Monitor) HasOverallStateModified() bool {
-	if m != nil && m.OverallStateModified != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetOverallStateModified allocates a new m.OverallStateModified and returns the pointer to it.
-func (m *Monitor) SetOverallStateModified(v string) {
-	m.OverallStateModified = &v
-}
-
 // GetQuery returns the Query field if non-nil, zero value otherwise.
 func (m *Monitor) GetQuery() string {
 	if m == nil || m.Query == nil {

--- a/monitors.go
+++ b/monitors.go
@@ -116,17 +116,17 @@ type State struct {
 // Monitor allows watching a metric or check that you care about,
 // notifying your team when some defined threshold is exceeded
 type Monitor struct {
-	Creator              *Creator `json:"creator,omitempty"`
-	Id                   *int     `json:"id,omitempty"`
-	Type                 *string  `json:"type,omitempty"`
-	Query                *string  `json:"query,omitempty"`
-	Name                 *string  `json:"name,omitempty"`
-	Message              *string  `json:"message,omitempty"`
-	OverallState         *string  `json:"overall_state,omitempty"`
-	OverallStateModified *string  `json:"overall_state_modified,omitempty"`
-	Tags                 []string `json:"tags"`
-	Options              *Options `json:"options,omitempty"`
-	State                State    `json:"state,omitempty"`
+	Creator              *Creator    `json:"creator,omitempty"`
+	Id                   *int        `json:"id,omitempty"`
+	Type                 *string     `json:"type,omitempty"`
+	Query                *string     `json:"query,omitempty"`
+	Name                 *string     `json:"name,omitempty"`
+	Message              *string     `json:"message,omitempty"`
+	OverallState         *string     `json:"overall_state,omitempty"`
+	OverallStateModified interface{} `json:"overall_state_modified,omitempty"`
+	Tags                 []string    `json:"tags"`
+	Options              *Options    `json:"options,omitempty"`
+	State                State       `json:"state,omitempty"`
 }
 
 // Creator contains the creator of the monitor
@@ -259,6 +259,18 @@ func (client *Client) GetMonitorsWithOptions(opts MonitorQueryOpts) ([]Monitor, 
 	if err != nil {
 		return nil, err
 	}
+	return out.Monitors, nil
+}
+
+// SearchMonitors retrieves monitors by a slice of notifications
+func (client *Client) SearchMonitors(query string) ([]Monitor, error) {
+	var out reqMonitors
+
+	err := client.doJsonRequest("GET", fmt.Sprintf("/v1/monitor/search?query=%v", query), nil, &out)
+	if err != nil {
+		return nil, err
+	}
+
 	return out.Monitors, nil
 }
 


### PR DESCRIPTION
Add Support for Monitor Search, see https://docs.datadoghq.com/api/v1/monitors/#monitors-search

Note: OverallStateModified is not a string when using the monitors/search but an int