### PR TITLE
Make API key validation succeed without app key

### DIFF
--- a/client.go
+++ b/client.go
@@ -99,7 +99,9 @@ func (client *Client) Validate() (bool, error) {
 		return false, err
 	}
 	req.Header.Set("DD-API-KEY", client.apiKey)
-	req.Header.Set("DD-APPLICATION-KEY", client.appKey)
+	if (client.appKey != "") {
+		req.Header.Set("DD-APPLICATION-KEY", client.appKey)
+	}
 
 	resp, err = client.doRequestWithRetries(req, client.RetryTimeout)
 	if err != nil {

--- a/integration/client_test.go
+++ b/integration/client_test.go
@@ -30,6 +30,17 @@ func TestValidAuth(t *testing.T) {
 	assert.Equal(t, valid, true)
 }
 
+func TestValidAuthNoAppKey(t *testing.T) {
+	c := datadog.NewClient(os.Getenv("DATADOG_API_KEY"), "")
+	valid, err := c.Validate()
+
+	if err != nil {
+		t.Fatalf("Testing authentication failed when it shouldn't: %s", err)
+	}
+
+	assert.Equal(t, valid, true)
+}
+
 func TestBaseUrl(t *testing.T) {
 	t.Run("Base url defaults to https://api.datadoghq.com", func(t *testing.T) {
 		assert.Empty(t, os.Getenv("DATADOG_HOST"))


### PR DESCRIPTION
Do not send the `DD-APPLICATION-KEY` header when the appkey is not set (ie. set to an empty string) on the client.

Sending a `GET` request to the `api/v1/validate` endpoint with a valid `DD-API-KEY` and no `DD-APPLICATION-KEY` succeeds.
Sending a GET request to the `api/v1/validate` endpoint with a valid `DD-API-KEY` and `DD-APPLICATION-KEY` set to an empty string fails.

This PR allows the API key validation method to succeed even when only an API key is used (which is enough in some use cases where an app key is not needed to access relevant endpoints).

Use case: the datadog opentelemetry exporter, which uses this library to send metrics, and only requires an API key to do its operations.