### PR TITLE
[monitor] Support group_states parameter for monitor GET

### DIFF
--- a/monitors.go
+++ b/monitors.go
@@ -181,6 +181,15 @@ func (client *Client) GetMonitor(id int) (*Monitor, error) {
 	return &out, nil
 }
 
+// GetMonitorGroupStates retrieves a monitor by identifier and passes the group_states parameter
+func (client *Client) GetMonitorGroupStates(id int, state string) (*Monitor, error) {
+	var out Monitor
+	if err := client.doJsonRequest("GET", fmt.Sprintf("/v1/monitor/%d?group_states=%s", id, state), nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
 // GetMonitorsByName retrieves monitors by name
 func (client *Client) GetMonitorsByName(name string) ([]Monitor, error) {
 	return client.GetMonitorsWithOptions(MonitorQueryOpts{Name: &name})


### PR DESCRIPTION
The monitor GET endpoint has the following optional parameter `group_states`

`/v1/monitor/<monitor_id>?group_states=<states>`

this can be `all`, `alert`, etc to indicate that you want only certain monitor groups. `all` is important because the default if not specified is only to have the overall state of the monitor.

For certain applications having all the monitor groups is very useful, hence this PR.